### PR TITLE
feat(web): add coordination games manifest shell

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-    <title>Capture the Lobster 🦞</title>
+    <title>Coordination Games 🎮</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import { PLATFORM_GITHUB_URL, PLATFORM_NAME, PLATFORM_SHORT_NAME } from '../games/manifest';
 
 function navLinkClass({ isActive }: { isActive: boolean }) {
   return `font-heading text-sm tracking-wider uppercase ${
@@ -22,12 +23,12 @@ export default function Layout() {
       }}>
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <NavLink to="/" className="flex items-center gap-2 sm:gap-3 hover:opacity-90 transition-opacity">
-            <span className="text-2xl sm:text-4xl" role="img" aria-label="lobster">
-              🦞
+            <span className="text-2xl sm:text-4xl" role="img" aria-label="games">
+              🎮
             </span>
             <h1 className="font-heading font-bold tracking-wide" style={{ color: 'var(--color-parchment)' }}>
-              <span className="hidden sm:inline text-xl">Capture the Lobster</span>
-              <span className="sm:hidden text-lg">CTL</span>
+              <span className="hidden sm:inline text-xl">{PLATFORM_NAME}</span>
+              <span className="sm:hidden text-lg">{PLATFORM_SHORT_NAME}</span>
             </h1>
           </NavLink>
 
@@ -43,7 +44,7 @@ export default function Layout() {
               Leaderboard
             </NavLink>
             <a
-              href="https://github.com/lucianHymer/capture-the-lobster"
+              href={PLATFORM_GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="transition-colors"
@@ -82,7 +83,7 @@ export default function Layout() {
               Leaderboard
             </NavLink>
             <a
-              href="https://github.com/lucianHymer/capture-the-lobster"
+              href={PLATFORM_GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="font-heading text-sm tracking-wider uppercase transition-colors"

--- a/packages/web/src/components/lobby/JoinInstructions.tsx
+++ b/packages/web/src/components/lobby/JoinInstructions.tsx
@@ -1,14 +1,17 @@
 import { useState } from 'react';
+import { buildJoinPrompt, getGameDisplayName, PLATFORM_INSTALL_COMMAND } from '../../games/manifest';
 
-export default function JoinInstructions({ lobbyId }: { lobbyId: string }) {
+export default function JoinInstructions({ lobbyId, gameType }: { lobbyId: string; gameType?: string }) {
   const [copied, setCopied] = useState(false);
+  const gameName = getGameDisplayName(gameType);
+  const joinPrompt = buildJoinPrompt(lobbyId, gameType);
 
   function handleCopyInstall() {
-    navigator.clipboard.writeText('claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster').then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
+    navigator.clipboard.writeText(PLATFORM_INSTALL_COMMAND).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
   }
 
   function handleCopyJoinPrompt() {
-    navigator.clipboard.writeText(`Join lobby ${lobbyId} on Capture the Lobster and play, please!`).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
+    navigator.clipboard.writeText(joinPrompt).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
   }
 
   return (
@@ -17,12 +20,12 @@ export default function JoinInstructions({ lobbyId }: { lobbyId: string }) {
       <p className="mb-2 text-xs" style={{ color: 'var(--color-ink-light)' }}>1. Install the plugin (one time):</p>
       <div onClick={handleCopyInstall} className="cursor-pointer rounded px-3 py-2 font-mono text-xs transition-colors hover:brightness-95" title="Click to copy"
         style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-ink-light)', border: '1px solid rgba(42, 31, 14, 0.08)' }}>
-        claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster
+        {PLATFORM_INSTALL_COMMAND}
       </div>
       <p className="mt-3 mb-2 text-xs" style={{ color: 'var(--color-ink-light)' }}>2. Tell your agent:</p>
       <div onClick={handleCopyJoinPrompt} className="cursor-pointer rounded px-3 py-2 font-mono text-xs transition-colors hover:brightness-95" title="Click to copy"
         style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-amber)', border: '1px solid rgba(184, 134, 11, 0.15)' }}>
-        "Join lobby {lobbyId} on Capture the Lobster and play, please!"
+        {`"Join lobby ${lobbyId} in Coordination Games and play ${gameName}, please!"`}
       </div>
       <p className="mt-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>{copied ? 'Copied!' : 'Click to copy'}</p>
     </div>

--- a/packages/web/src/games/manifest.ts
+++ b/packages/web/src/games/manifest.ts
@@ -57,6 +57,12 @@ const GAME_MANIFEST: GameManifestEntry[] = [
     tagline: 'Resource management, trade, and reputation',
     availability: 'prototype',
     accentColor: '#34d399',
+    lobby: {
+      options: [4, 5, 6],
+      optionDisplay: 'count',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Players',
+    },
   },
   {
     gameType: 'ai-alignment',

--- a/packages/web/src/games/manifest.ts
+++ b/packages/web/src/games/manifest.ts
@@ -1,0 +1,95 @@
+export type GameAvailability = 'live' | 'prototype' | 'concept';
+export type LobbyOptionDisplay = 'versus' | 'count';
+
+export interface GameManifestEntry {
+  gameType: string;
+  displayName: string;
+  shortName: string;
+  tagline: string;
+  availability: GameAvailability;
+  accentColor: string;
+  lobby?: {
+    options: number[];
+    optionDisplay: LobbyOptionDisplay;
+    buttonLabel: string;
+    metricLabel: string;
+  };
+}
+
+export const PLATFORM_NAME = 'Coordination Games';
+export const PLATFORM_SHORT_NAME = 'CG';
+export const PLATFORM_INSTALL_COMMAND = 'npx skills add -g lucianHymer/coordination';
+export const PLATFORM_GITHUB_URL = 'https://github.com/coordination-games/coordination-games';
+
+const GAME_MANIFEST: GameManifestEntry[] = [
+  {
+    gameType: 'capture-the-lobster',
+    displayName: 'Capture the Lobster',
+    shortName: 'CtL',
+    tagline: 'Team tactics under fog of war',
+    availability: 'live',
+    accentColor: 'var(--color-forest)',
+    lobby: {
+      options: [2, 3, 4, 5, 6],
+      optionDisplay: 'versus',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Teams',
+    },
+  },
+  {
+    gameType: 'oathbreaker',
+    displayName: 'OATHBREAKER',
+    shortName: 'OATH',
+    tagline: 'Iterated trust under real stakes',
+    availability: 'live',
+    accentColor: 'var(--color-blood)',
+    lobby: {
+      options: [4, 6, 8, 10, 12, 16, 20],
+      optionDisplay: 'count',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Players',
+    },
+  },
+  {
+    gameType: 'comedy-of-the-commons',
+    displayName: 'Comedy of the Commons',
+    shortName: 'Comedy',
+    tagline: 'Resource management, trade, and reputation',
+    availability: 'prototype',
+    accentColor: '#34d399',
+  },
+  {
+    gameType: 'ai-alignment',
+    displayName: 'AI Alignment',
+    shortName: 'Alignment',
+    tagline: 'Coordination under existential pressure',
+    availability: 'concept',
+    accentColor: '#fb7185',
+  },
+];
+
+export function getAllGameManifest(): GameManifestEntry[] {
+  return GAME_MANIFEST;
+}
+
+export function getLobbyEnabledGames(): GameManifestEntry[] {
+  return GAME_MANIFEST.filter((game) => game.lobby);
+}
+
+export function getGameManifest(gameType?: string | null): GameManifestEntry | undefined {
+  if (!gameType) return undefined;
+  return GAME_MANIFEST.find((game) => game.gameType === gameType);
+}
+
+export function getGameDisplayName(gameType?: string | null): string {
+  return getGameManifest(gameType)?.displayName ?? 'Unknown Game';
+}
+
+export function formatLobbyOption(game: GameManifestEntry, value: number): string {
+  if (!game.lobby) return String(value);
+  return game.lobby.optionDisplay === 'versus' ? `${value}v${value}` : String(value);
+}
+
+export function buildJoinPrompt(lobbyId: string, gameType?: string | null): string {
+  return `Join lobby ${lobbyId} in ${PLATFORM_NAME} and play ${getGameDisplayName(gameType)}, please!`;
+}

--- a/packages/web/src/pages/GamePage.tsx
+++ b/packages/web/src/pages/GamePage.tsx
@@ -53,7 +53,7 @@ export default function GamePage() {
     fetch(`${API_BASE}/games/${id}`)
       .then(r => r.json())
       .then(data => {
-        setGameType(data.gameType ?? 'capture-the-lobster');
+        setGameType(data.gameType ?? 'unknown');
         const h = extractHandles(data);
         if (Object.keys(h).length) setHandles(h);
         const c = extractChat(data);
@@ -61,7 +61,7 @@ export default function GamePage() {
         setLoading(false);
       })
       .catch(() => {
-        setGameType('capture-the-lobster');
+        setGameType('unknown');
         setLoading(false);
       });
 

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { fetchGames } from '../api';
+import { getAllGameManifest, PLATFORM_INSTALL_COMMAND, PLATFORM_NAME } from '../games/manifest';
 
 function CopyBlock({ text, display }: { text: string; display?: string }) {
   const [copied, setCopied] = useState(false);
@@ -56,6 +57,7 @@ const fadeUp = {
 
 export default function HomePage() {
   const [activeCount, setActiveCount] = useState(0);
+  const featuredGames = getAllGameManifest().filter((game) => game.availability === 'live');
 
   useEffect(() => {
     let cancelled = false;
@@ -116,33 +118,38 @@ export default function HomePage() {
         />
 
         <div className="relative z-10 px-8 py-12 sm:px-12 sm:py-16 space-y-8">
-          {/* Unit sprites */}
+          {/* Featured games */}
           <motion.div className="flex justify-center gap-6 mb-2" variants={fadeUp}>
-            {['rogue', 'knight', 'mage'].map((unit, i) => (
-              <motion.img
-                key={unit}
-                src={`/tiles/units/${unit}.png`}
-                alt={unit}
-                className="w-24 h-24 sm:w-32 sm:h-32"
-                style={{ imageRendering: 'pixelated', filter: 'drop-shadow(0 0 8px rgba(212, 162, 78, 0.4))' }}
+            {featuredGames.map((game, i) => (
+              <motion.div
+                key={game.gameType}
+                className="rounded-full px-4 py-2 text-xs font-heading font-semibold uppercase tracking-[0.2em]"
+                style={{
+                  color: game.accentColor,
+                  background: 'rgba(212, 162, 78, 0.06)',
+                  border: `1px solid ${game.accentColor}55`,
+                  boxShadow: `0 0 8px ${game.accentColor}22`,
+                }}
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 + i * 0.12, duration: 0.5 }}
-              />
+              >
+                {game.displayName}
+              </motion.div>
             ))}
           </motion.div>
 
           {/* Title */}
           <motion.div className="text-center space-y-2" variants={fadeUp}>
             <h2 className="font-heading text-3xl sm:text-4xl font-bold tracking-wide leading-tight" style={{ color: 'var(--color-parchment)' }}>
-              Capture the Lobster
+              {PLATFORM_NAME}
             </h2>
             <p className="font-heading text-sm sm:text-base tracking-wide leading-relaxed max-w-lg mx-auto" style={{ color: 'var(--color-parchment-dark)' }}>
-              A game where agents learn to find teammates, coordinate,
-              and actually get things done together.
+              A platform for multiplayer agent games where strategy,
+              coordination, and reputation can evolve across repeated play.
             </p>
             <p className="font-heading text-sm sm:text-base tracking-wide" style={{ color: 'var(--color-amber-glow)' }}>
-              You — and your agents — build the tools.
+              Bring your agents. Build better harnesses. Study what wins.
             </p>
           </motion.div>
 
@@ -161,14 +168,14 @@ export default function HomePage() {
                 <span className="flex-none w-4 h-4 rounded-full text-[9px] font-bold flex items-center justify-center font-heading" style={{ background: 'rgba(212, 162, 78, 0.2)', color: 'var(--color-amber-glow)' }}>1</span>
                 <span className="font-heading text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-amber-dim)' }}>Install the MCP skill</span>
               </div>
-              <CopyBlock text="claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster" />
+              <CopyBlock text={PLATFORM_INSTALL_COMMAND} />
             </div>
             <div className="space-y-1.5">
               <div className="flex items-center gap-2">
                 <span className="flex-none w-4 h-4 rounded-full text-[9px] font-bold flex items-center justify-center font-heading" style={{ background: 'rgba(212, 162, 78, 0.2)', color: 'var(--color-amber-glow)' }}>2</span>
                 <span className="font-heading text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-amber-dim)' }}>Ask your agent</span>
               </div>
-              <CopyBlock text="Tell me about Capture the Lobster, please!" display={'"Tell me about Capture the Lobster, please!"'} />
+              <CopyBlock text="Show me the live games in Coordination Games and help me join a lobby." display={'"Show me the live games in Coordination Games and help me join a lobby."'} />
             </div>
           </motion.div>
         </div>

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -24,10 +24,17 @@ interface Lobby {
   lobbyId: string;
   gameType?: string;
   phase: 'running' | 'starting' | 'game' | 'failed';
-  teamSize?: number;
   playerCount?: number;
-  createdAt?: string;
+  currentPhase?: {
+    id: string;
+    name: string;
+    view: any;
+  } | null;
+  agents: any[];
+  deadlineMs?: number | null;
   gameId?: string | null;
+  error?: string | null;
+  noTimeout?: boolean;
 }
 
 function phaseBadge(phase: string) {
@@ -248,7 +255,7 @@ function lobbyPhaseBadge(lobby: Lobby) {
       return (
         <span className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-heading font-medium tracking-wide" style={{ background: 'rgba(184, 134, 11, 0.08)', color: 'var(--color-amber)', border: '1px solid rgba(184, 134, 11, 0.2)' }}>
           <span className="h-1.5 w-1.5 rounded-full animate-pulse" style={{ background: 'var(--color-amber)' }} />
-          Open
+          {phaseName ?? 'In Progress'}
         </span>
       );
     case 'starting':

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { API_BASE } from '../config.js';
 import { motion } from 'framer-motion';
 import { fetchGames, type GameSummary } from '../api';
+import { formatLobbyOption, getGameManifest, getLobbyEnabledGames } from '../games/manifest';
 
 interface Game {
   id: string;
@@ -57,13 +58,19 @@ function phaseBadge(phase: string) {
 }
 
 export default function LobbiesPage() {
+  const lobbyGames = getLobbyEnabledGames();
+  const defaultGame = lobbyGames[0]?.gameType ?? 'capture-the-lobster';
   const [games, setGames] = useState<Game[]>([]);
   const [lobbies, setLobbies] = useState<Lobby[]>([]);
   const [creating, setCreating] = useState(false);
-  const [teamSize, setTeamSize] = useState(2);
-  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker'>('capture-the-lobster');
-  const [oathPlayerCount, setOathPlayerCount] = useState(4);
+  const [gameTab, setGameTab] = useState<string>(defaultGame);
+  const [createValue, setCreateValue] = useState<number>(getGameManifest(defaultGame)?.lobby?.options[0] ?? 2);
   const navigate = useNavigate();
+  const selectedGame = getGameManifest(gameTab);
+
+  useEffect(() => {
+    setCreateValue(selectedGame?.lobby?.options[0] ?? 2);
+  }, [selectedGame?.gameType]);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,25 +107,17 @@ export default function LobbiesPage() {
   async function handleCreateLobby() {
     setCreating(true);
     try {
-      if (gameTab === 'oathbreaker') {
-        const res = await fetch(`${API_BASE}/lobbies/create`, {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ gameType: 'oathbreaker', playerCount: oathPlayerCount }),
-        });
-        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
-      } else {
-        const res = await fetch(`${API_BASE}/lobbies/create`, {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ teamSize }),
-        });
-        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
-      }
+      const res = await fetch(`${API_BASE}/lobbies/create`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gameType: gameTab, teamSize: createValue }),
+      });
+      if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
     } catch {}
     setCreating(false);
   }
 
-  const filteredGames = games.filter(g => (g.gameType ?? 'capture-the-lobster') === gameTab);
-  const filteredLobbies = lobbies.filter(l => (l.gameType ?? 'capture-the-lobster') === gameTab);
+  const filteredGames = games.filter(g => (g.gameType ?? defaultGame) === gameTab);
+  const filteredLobbies = lobbies.filter(l => (l.gameType ?? defaultGame) === gameTab);
   const activeGames = filteredGames.filter((g) => g.phase !== 'finished');
   const finishedGames = filteredGames.filter((g) => g.phase === 'finished');
 
@@ -128,60 +127,40 @@ export default function LobbiesPage() {
       <div className="flex flex-col gap-3">
         {/* Tab selector */}
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => setGameTab('capture-the-lobster')}
-            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
-            style={gameTab === 'capture-the-lobster'
-              ? { background: 'rgba(58, 90, 42, 0.15)', color: 'var(--color-forest)', border: '1px solid rgba(58, 90, 42, 0.3)' }
-              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-            }
-          >
-            Capture the Lobster
-          </button>
-          <button
-            onClick={() => setGameTab('oathbreaker')}
-            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
-            style={gameTab === 'oathbreaker'
-              ? { background: 'rgba(139, 32, 32, 0.12)', color: 'var(--color-blood)', border: '1px solid rgba(139, 32, 32, 0.3)' }
-              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-            }
-          >
-            OATHBREAKER
-          </button>
+          {lobbyGames.map((game) => {
+            const isActive = gameTab === game.gameType;
+            return (
+              <button
+                key={game.gameType}
+                onClick={() => setGameTab(game.gameType)}
+                className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
+                style={isActive
+                  ? { background: `${game.accentColor}20`, color: game.accentColor, border: `1px solid ${game.accentColor}55` }
+                  : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+                }
+              >
+                {game.displayName}
+              </button>
+            );
+          })}
         </div>
 
         {/* Create controls */}
         <div className="flex items-center justify-end gap-3">
-          {gameTab === 'capture-the-lobster' ? (
+          {selectedGame?.lobby && (
             <div className="flex items-center gap-2">
-              {[2, 3, 4, 5, 6].map((size) => (
+              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>{selectedGame.lobby.metricLabel}:</span>
+              {selectedGame.lobby.options.map((option) => (
                 <button
-                  key={size}
-                  onClick={() => setTeamSize(size)}
-                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
-                  style={teamSize === size
-                    ? { background: 'rgba(212, 162, 78, 0.15)', color: 'var(--color-amber-glow)', border: '1px solid rgba(212, 162, 78, 0.4)' }
+                  key={option}
+                  onClick={() => setCreateValue(option)}
+                  className="cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors"
+                  style={createValue === option
+                    ? { background: `${selectedGame.accentColor}20`, color: selectedGame.accentColor, border: `1px solid ${selectedGame.accentColor}55` }
                     : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
                   }
                 >
-                  {size}v{size}
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
-              {[4, 6, 8, 10, 12, 16, 20].map((count) => (
-                <button
-                  key={count}
-                  onClick={() => setOathPlayerCount(count)}
-                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
-                  style={oathPlayerCount === count
-                    ? { background: 'rgba(139, 32, 32, 0.15)', color: 'var(--color-blood-light, #c55)', border: '1px solid rgba(139, 32, 32, 0.4)' }
-                    : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-                  }
-                >
-                  {count}
+                  {formatLobbyOption(selectedGame, option)}
                 </button>
               ))}
             </div>
@@ -194,7 +173,7 @@ export default function LobbiesPage() {
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
-            {creating ? 'Creating...' : 'Create Lobby'}
+            {creating ? 'Creating...' : (selectedGame?.lobby?.buttonLabel ?? 'Create Lobby')}
           </motion.button>
         </div>
       </div>
@@ -262,6 +241,7 @@ function SectionHeader({ title, count }: { title: string; count?: number }) {
 
 function lobbyPhaseBadge(lobby: Lobby) {
   const phase = lobby.phase;
+  const phaseName = lobby.currentPhase?.name;
 
   switch (phase) {
     case 'running':
@@ -290,10 +270,12 @@ function lobbyPhaseBadge(lobby: Lobby) {
 function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
   const playerCount = lobby.playerCount ?? 0;
   const gameType = lobby.gameType ?? 'capture-the-lobster';
-  const teamSize = lobby.teamSize;
-  const capacity = teamSize != null
-    ? (gameType === 'oathbreaker' ? teamSize : teamSize * 2)
-    : undefined;
+  const manifest = getGameManifest(gameType);
+  const phaseView = lobby.currentPhase?.view;
+
+  // Extract team count from team-formation phase view if available
+  const teams: any[] = phaseView?.teams ?? [];
+  const teamCount = teams.length;
 
   return (
     <button onClick={onClick} className="group cursor-pointer w-full rounded-xl parchment-strong p-5 text-left transition-all duration-200 hover:shadow-md">
@@ -302,15 +284,19 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
         {lobbyPhaseBadge(lobby)}
       </div>
       <div className="mb-2 text-sm" style={{ color: 'var(--color-ink-light)' }}>
-        <span className="font-semibold" style={{ color: 'var(--color-amber)' }}>{playerCount}</span>
-        {capacity != null ? <span>/{capacity}</span> : null} players
-        {teamSize != null && gameType !== 'oathbreaker' && (
-          <span className="ml-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>· {teamSize}v{teamSize}</span>
-        )}
+        <span className="font-semibold" style={{ color: 'var(--color-amber)' }}>{playerCount}</span> players
+        {teamCount > 0 && <span className="ml-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>· {teamCount} teams</span>}
       </div>
-      <div className="flex items-center justify-end">
-        {gameType === 'oathbreaker' && (
-          <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>OATHBREAKER</span>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap gap-1">
+          {lobby.agents.slice(0, 8).map((agent: any) => (
+            <span key={agent.id} className="inline-block rounded-md px-1.5 py-0.5 text-xs font-mono" style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-ink-faint)' }}>
+              {agent.handle || agent.id}
+            </span>
+          ))}
+        </div>
+        {manifest && (
+          <span className="font-heading text-xs font-medium" style={{ color: manifest.accentColor }}>{manifest.displayName}</span>
         )}
       </div>
     </button>
@@ -318,6 +304,7 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
 }
 
 function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
+  const manifest = getGameManifest(game.gameType ?? 'capture-the-lobster');
   // OATHBREAKER game card
   if (game.gameType === 'oathbreaker') {
     const round = game.round ?? game.turn ?? 0;
@@ -351,8 +338,8 @@ function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
           </div>
         </div>
         <div className="flex items-center justify-between text-sm">
-          <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>
-            OATHBREAKER
+          <span className="font-heading text-xs font-medium" style={{ color: manifest?.accentColor ?? 'var(--color-blood)' }}>
+            {manifest?.displayName ?? 'OATHBREAKER'}
           </span>
           <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>
             {game.playerCount ?? '?'} players

--- a/packages/web/src/pages/LobbyPage.tsx
+++ b/packages/web/src/pages/LobbyPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { API_BASE, getWsUrl } from '../config.js';
-import { PlayerList, ChatPanel, AutoScrollChat, TimerBar, JoinInstructions, TeamPanel } from '../components/lobby';
+import { PlayerList, ChatPanel, TimerBar, JoinInstructions, TeamPanel } from '../components/lobby';
+import { getGameDisplayName } from '../games/manifest';
 
 // ---------------------------------------------------------------------------
 // Shared types — matches the new generic LobbyDO state shape
@@ -227,8 +228,8 @@ export default function LobbyPage() {
   if (!state) return null;
 
   // Derive display info from the new state shape
-  const gameType = state.gameType ?? 'capture-the-lobster';
-  const gameLabel = gameType === 'oathbreaker' ? 'OATHBREAKER' : 'Capture the Lobster';
+  const gameType = state.gameType;
+  const gameLabel = getGameDisplayName(gameType);
   const phaseId = state.currentPhase?.id;
   const phaseView = state.currentPhase?.view;
   const chatMessages = extractChatMessages(state.relay ?? []);
@@ -236,7 +237,6 @@ export default function LobbyPage() {
   // Determine if this is a team-based or simple lobby from phase view data
   const isTeamPhase = phaseId === 'team-formation';
   const isClassSelection = phaseId === 'class-selection';
-  const isOpenQueue = phaseId === 'open-queue';
   const showTimer = state.phase === 'running' && state.deadlineMs != null;
 
   // Team formation view: { teams: [{id, members, invites}], unassigned, teamSize, numTeams }
@@ -248,9 +248,7 @@ export default function LobbyPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="font-heading text-xl font-bold" style={{ color: 'var(--color-ink)' }}>Lobby</h1>
-          {gameType !== 'capture-the-lobster' && (
-            <span className="font-heading text-sm font-medium" style={{ color: 'var(--color-blood)' }}>{gameLabel}</span>
-          )}
+          <span className="font-heading text-sm font-medium" style={{ color: 'var(--color-blood)' }}>{gameLabel}</span>
           <span className="font-mono text-sm" style={{ color: 'var(--color-ink-faint)' }}>{state.lobbyId}</span>
           {phaseBadge(state.phase, phaseId)}
           <span className="text-sm" style={{ color: 'var(--color-ink-light)' }}>{state.agents.length} agents</span>
@@ -284,7 +282,7 @@ export default function LobbyPage() {
 
       {/* Running phase: Join instructions */}
       {state.phase === 'running' && (
-        <JoinInstructions lobbyId={state.lobbyId} />
+        <JoinInstructions lobbyId={state.lobbyId} gameType={gameType} />
       )}
 
       {/* Game redirect */}


### PR DESCRIPTION
# PR Notes — `djimo/game-manifest-shell-r1`

## Branch

- Repo: `coordination-games`
- Branch: `djimo/game-manifest-shell-r1`
- PR URL: `https://github.com/coordination-games/coordination-games/pull/new/djimo/game-manifest-shell-r1`

## Suggested PR title

`Neutralize the shell and drive lobby browsing from game manifest data`

## Suggested PR summary

This branch is the current canonical shell/product refresh against latest upstream main. It keeps the shell work intentionally web-scoped: a small manifest layer drives product naming, lobby tabs, create controls, and game-aware join surfaces without claiming runtime discovery is solved yet.

It also carries the small follow-up that makes Comedy a real lobby-enabled manifest entry, so Comedy can appear in the manifest-driven lobbies flow without requiring a second hardcoded shell path.

## What changed

### Manifest + branding
- adds `packages/web/src/games/manifest.ts`
- rebrands the shell from CtL-first wording toward `Coordination Games`

### Game-aware lobby surfaces
- makes join instructions game-aware
- updates lobby page labels to derive from the manifest
- makes `LobbiesPage` render tabs and create controls from manifest metadata

### Comedy follow-up
- enables Comedy as a manifest-backed lobby game via the `lobby` block in `manifest.ts`

## Validation evidence

- `packages/web` build passed on the refreshed branch
- the branch was adapted to latest-main `Lobby` shape rather than replayed blindly
- the shell behavior was validated later through the `djimo/dev` integration lane

## Important non-goals

- does **not** solve dynamic runtime game discovery
- does **not** solve worker/runtime registration
- does **not** claim final shell/landing-page marketing polish

## Review focus

1. Is the manifest the right presentation-only bridge until runtime metadata discovery exists?
2. Are the shell and lobby surfaces now neutral enough for additional games without overreaching?
3. Is it acceptable to keep Comedy manifest-backed here while deeper runtime work remains on the Comedy branch?
