### PR TITLE
feat(comedy): add latest-main Comedy start path

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/plugins/*"
   ],
   "scripts": {
-    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/plugins/basic-chat -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
+    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/games/comedy-of-the-commons -w packages/plugins/basic-chat -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
     "test": "npm run test --workspaces --if-present",
     "dev": "npm run dev --workspace=packages/workers-server",
     "dev:web": "npm run dev --workspace=packages/web",

--- a/packages/games/comedy-of-the-commons/README.md
+++ b/packages/games/comedy-of-the-commons/README.md
@@ -1,0 +1,46 @@
+# Comedy of the Commons
+
+Initial upstream package scaffold for bringing **Comedy of the Commons** into the `coordination-games` engine as a normal `CoordinationGame` plugin.
+
+This package is intentionally being built in phases.
+
+## Purpose of this first slice
+
+This branch starts the upstream port without pretending the full local prototype is already ported.
+
+What this first step does:
+
+- reserves the upstream package path
+- defines the initial v0 type surface
+- records the source-material mapping back to the richer local prototype
+
+What this first step does **not** claim yet:
+
+- full gameplay loop parity
+- trust portability
+- commitment / attestation parity
+- Olympiad support
+
+## Local source material
+
+Primary source files currently live in the local arena prototype:
+
+- `arena/src/games/nexus/comedy-engine.ts`
+- `arena/src/games/nexus/types.ts`
+- `arena/src/games/nexus/world-map.ts`
+- `arena/src/games/nexus/trade.ts`
+
+The upstream port should stay smaller than the local prototype at first.
+
+## Intended v0 shape
+
+Comedy v0 should become the smallest playable upstream slice:
+
+- game package under `packages/games/comedy-of-the-commons`
+- simple config builder / lobby path
+- spectator plugin later
+- basic resource, commons, trading, and building loop
+
+## Rule
+
+Do not silently port every rich subsystem from the local arena. Add only what is required for a believable playable v0, then layer v1/v2 features in later slices.

--- a/packages/games/comedy-of-the-commons/package.json
+++ b/packages/games/comedy-of-the-commons/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@coordination-games/game-comedy-of-the-commons",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --skipLibCheck"
+  },
+  "dependencies": {
+    "@coordination-games/engine": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/games/comedy-of-the-commons/src/game.ts
+++ b/packages/games/comedy-of-the-commons/src/game.ts
@@ -1,0 +1,488 @@
+import type { ActionResult } from '@coordination-games/engine';
+import {
+  type ComedyAction,
+  type ComedyConfig,
+  type ComedyEcosystem,
+  type ComedyOutcome,
+  type ComedyPlayerState,
+  type ComedyRegion,
+  type ComedyState,
+  type ComedyTradeOffer,
+  type ExtractionLevel,
+  type ResourceInventory,
+  type ResourceType,
+} from './types.js';
+
+const RESOURCE_CAP = 14;
+const SETTLEMENT_COST: Partial<ResourceInventory> = {
+  grain: 1,
+  timber: 1,
+  ore: 1,
+  water: 1,
+};
+
+const EXTRACTION_PROFILES: Record<ExtractionLevel, { yield: number; pressure: number }> = {
+  low: { yield: 1, pressure: 1 },
+  medium: { yield: 2, pressure: 3 },
+  high: { yield: 3, pressure: 6 },
+};
+
+const STARTING_RESOURCES: ResourceInventory = {
+  grain: 2,
+  timber: 2,
+  ore: 1,
+  fish: 1,
+  water: 1,
+  energy: 1,
+};
+
+function cloneResources(resources: ResourceInventory): ResourceInventory {
+  return { ...resources };
+}
+
+function totalResources(resources: ResourceInventory): number {
+  return Object.values(resources).reduce((sum, value) => sum + value, 0);
+}
+
+function canAfford(resources: ResourceInventory, cost: Partial<ResourceInventory>): boolean {
+  return Object.entries(cost).every(([key, value]) => resources[key as ResourceType] >= (value ?? 0));
+}
+
+function deductCost(resources: ResourceInventory, cost: Partial<ResourceInventory>): void {
+  for (const [key, value] of Object.entries(cost)) {
+    resources[key as ResourceType] -= value ?? 0;
+  }
+}
+
+function addResource(resources: ResourceInventory, resource: ResourceType, amount: number): number {
+  const currentTotal = totalResources(resources);
+  if (currentTotal >= RESOURCE_CAP) return 0;
+  const accepted = Math.min(amount, RESOURCE_CAP - currentTotal);
+  resources[resource] += accepted;
+  return accepted;
+}
+
+function inventoryEquals(left: Partial<ResourceInventory>, right: Partial<ResourceInventory>): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if ((left[key as ResourceType] ?? 0) !== (right[key as ResourceType] ?? 0)) return false;
+  }
+  return true;
+}
+
+function getBaseRegions(): ComedyRegion[] {
+  return [
+    { id: 'mistbarrow', name: 'Mistbarrow', primaryResource: 'timber', secondaryResources: ['water'], ecosystemIds: ['old-growth-ring'] },
+    { id: 'riverwake', name: 'Riverwake', primaryResource: 'water', secondaryResources: ['fish', 'grain'], ecosystemIds: ['sunspine-aquifer'] },
+    { id: 'commons-heart', name: 'Commons Heart', primaryResource: 'grain', secondaryResources: ['timber', 'water'], ecosystemIds: ['old-growth-ring', 'sunspine-aquifer'] },
+    { id: 'sunspine-basin', name: 'Sunspine Basin', primaryResource: 'energy', secondaryResources: ['ore'], ecosystemIds: ['sunspine-aquifer'] },
+    { id: 'ironcrest', name: 'Ironcrest', primaryResource: 'ore', secondaryResources: ['energy'], ecosystemIds: [] },
+    { id: 'monsoon-reach', name: 'Monsoon Reach', primaryResource: 'fish', secondaryResources: ['water', 'grain'], ecosystemIds: ['silver-tide-fishery'] },
+  ];
+}
+
+function getBaseEcosystems(): ComedyEcosystem[] {
+  return [
+    {
+      id: 'old-growth-ring',
+      name: 'Old Growth Ring',
+      kind: 'forest',
+      resource: 'timber',
+      regionIds: ['mistbarrow', 'commons-heart'],
+      health: 16,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+    {
+      id: 'sunspine-aquifer',
+      name: 'Sunspine Aquifer',
+      kind: 'aquifer',
+      resource: 'water',
+      regionIds: ['riverwake', 'commons-heart', 'sunspine-basin'],
+      health: 15,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+    {
+      id: 'silver-tide-fishery',
+      name: 'Silver Tide Fishery',
+      kind: 'fishery',
+      resource: 'fish',
+      regionIds: ['monsoon-reach'],
+      health: 14,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+  ];
+}
+
+function createPlayers(playerIds: string[], regions: ComedyRegion[]): ComedyPlayerState[] {
+  return playerIds.map((id, index) => ({
+    id,
+    resources: cloneResources(STARTING_RESOURCES),
+    influence: 0,
+    vp: 1,
+    regionsControlled: [regions[index % regions.length].id],
+  }));
+}
+
+function makeSubmittedActions(playerIds: string[]): Record<string, ComedyAction | null> {
+  return Object.fromEntries(playerIds.map((id) => [id, null]));
+}
+
+function ecosystemStatus(ecosystem: ComedyEcosystem): 'flourishing' | 'stable' | 'strained' | 'collapsed' {
+  if (ecosystem.health <= ecosystem.collapseThreshold) return 'collapsed';
+  if (ecosystem.health >= ecosystem.flourishThreshold) return 'flourishing';
+  if (ecosystem.health <= Math.ceil(ecosystem.maxHealth / 2)) return 'strained';
+  return 'stable';
+}
+
+function getYieldMultiplier(ecosystem: ComedyEcosystem): number {
+  const status = ecosystemStatus(ecosystem);
+  if (status === 'flourishing') return 1.5;
+  if (status === 'collapsed') return 0.5;
+  if (status === 'strained') return 0.8;
+  return 1;
+}
+
+function applyProduction(state: ComedyState): ComedyState {
+  const ecosystems = state.ecosystems.map((ecosystem) => ({ ...ecosystem }));
+  const ecosystemById = new Map(ecosystems.map((ecosystem) => [ecosystem.id, ecosystem]));
+  const players = state.players.map((player) => ({ ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] }));
+  const regionsById = new Map(state.regions.map((region) => [region.id, region]));
+
+  for (const player of players) {
+    for (const regionId of player.regionsControlled) {
+      const region = regionsById.get(regionId);
+      if (!region) continue;
+      addResource(player.resources, region.primaryResource, 1);
+      for (const ecosystemId of region.ecosystemIds) {
+        const ecosystem = ecosystemById.get(ecosystemId);
+        if (ecosystem && ecosystemStatus(ecosystem) === 'flourishing') {
+          addResource(player.resources, ecosystem.resource, 1);
+          break;
+        }
+      }
+    }
+  }
+
+  return { ...state, players, ecosystems };
+}
+
+function startRound(state: ComedyState): ComedyState {
+  const round = state.round + 1;
+  const started = {
+    ...state,
+    round,
+    phase: 'playing' as const,
+    activeTrades: [],
+    submittedActions: makeSubmittedActions(state.players.map((player) => player.id)),
+  };
+  return applyProduction(started);
+}
+
+function allPlayersSubmitted(state: ComedyState): boolean {
+  return state.players.every((player) => state.submittedActions[player.id] !== null);
+}
+
+function resolveTrades(
+  players: ComedyPlayerState[],
+  submittedByPlayer: Array<{ playerId: string; action: ComedyAction }>,
+): ComedyTradeOffer[] {
+  const playerMap = new Map(players.map((player) => [player.id, player]));
+  const completed: ComedyTradeOffer[] = [];
+  const used = new Set<number>();
+
+  for (let i = 0; i < submittedByPlayer.length; i++) {
+    const current = submittedByPlayer[i];
+    if (current.action.type !== 'offer_trade' || used.has(i)) continue;
+    for (let j = i + 1; j < submittedByPlayer.length; j++) {
+      const other = submittedByPlayer[j];
+      if (other.action.type !== 'offer_trade' || used.has(j)) continue;
+      if (current.playerId === other.playerId) continue;
+      if (current.action.offer.to !== other.playerId) continue;
+      if (other.action.offer.to !== current.playerId) continue;
+      if (!inventoryEquals(current.action.offer.give, other.action.offer.receive)) continue;
+      if (!inventoryEquals(current.action.offer.receive, other.action.offer.give)) continue;
+
+      const actionSender = playerMap.get(current.playerId);
+      const otherSender = playerMap.get(other.playerId);
+      if (!actionSender || !otherSender) continue;
+      if (!canAfford(actionSender.resources, current.action.offer.give)) continue;
+      if (!canAfford(otherSender.resources, other.action.offer.give)) continue;
+
+      deductCost(actionSender.resources, current.action.offer.give);
+      deductCost(otherSender.resources, other.action.offer.give);
+      for (const [resource, amount] of Object.entries(current.action.offer.receive)) {
+        actionSender.resources[resource as ResourceType] += amount ?? 0;
+      }
+      for (const [resource, amount] of Object.entries(other.action.offer.receive)) {
+        otherSender.resources[resource as ResourceType] += amount ?? 0;
+      }
+      actionSender.influence += 1;
+      otherSender.influence += 1;
+      completed.push(current.action.offer, other.action.offer);
+      used.add(i);
+      used.add(j);
+      break;
+    }
+  }
+
+  return completed;
+}
+
+function resolveRound(state: ComedyState): ComedyState {
+  const players = state.players.map((player) => ({ ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] }));
+  const ecosystems = state.ecosystems.map((ecosystem) => ({ ...ecosystem }));
+  const ecosystemById = new Map(ecosystems.map((ecosystem) => [ecosystem.id, ecosystem]));
+  const submittedByPlayer = players.map((player) => ({
+    playerId: player.id,
+    action: state.submittedActions[player.id] ?? ({ type: 'pass' } as ComedyAction),
+  }));
+
+  const completedTrades = resolveTrades(players, submittedByPlayer);
+  const pressureByEcosystem = new Map<string, number>();
+
+  for (let index = 0; index < players.length; index++) {
+    const player = players[index];
+    const action = submittedByPlayer[index].action;
+    if (action.type === 'extract_commons') {
+      const ecosystem = ecosystemById.get(action.ecosystemId);
+      if (!ecosystem) continue;
+      const controlsRegion = ecosystem.regionIds.some((regionId) => player.regionsControlled.includes(regionId));
+      if (!controlsRegion) continue;
+      const profile = EXTRACTION_PROFILES[action.level];
+      const accepted = addResource(player.resources, ecosystem.resource, Math.max(1, Math.round(profile.yield * getYieldMultiplier(ecosystem))));
+      if (accepted > 0) {
+        pressureByEcosystem.set(ecosystem.id, (pressureByEcosystem.get(ecosystem.id) ?? 0) + profile.pressure);
+      }
+      continue;
+    }
+
+    if (action.type === 'build_settlement') {
+      if (!action.regionId) continue;
+      if (!canAfford(player.resources, SETTLEMENT_COST)) continue;
+      const regionTaken = players.some((other) => other.regionsControlled.includes(action.regionId));
+      if (regionTaken) continue;
+      deductCost(player.resources, SETTLEMENT_COST);
+      player.regionsControlled.push(action.regionId);
+      player.vp += 1;
+      player.influence += 1;
+    }
+  }
+
+  for (const ecosystem of ecosystems) {
+    const pressure = pressureByEcosystem.get(ecosystem.id) ?? 0;
+    const nextHealth = Math.max(0, Math.min(ecosystem.maxHealth, ecosystem.health + 2 - pressure));
+    ecosystem.health = nextHealth;
+  }
+
+  const flourishingEcosystems = ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'flourishing');
+  for (const ecosystem of flourishingEcosystems) {
+    for (const player of players) {
+      if (ecosystem.regionIds.some((regionId) => player.regionsControlled.includes(regionId))) {
+        player.influence += 1;
+      }
+    }
+  }
+
+  const rankings = [...players].sort((left, right) => {
+    if (right.vp !== left.vp) return right.vp - left.vp;
+    return right.influence - left.influence;
+  });
+  const winner = rankings[0]?.id ?? null;
+
+  return {
+    ...state,
+    players,
+    ecosystems,
+    activeTrades: completedTrades,
+    winner,
+  };
+}
+
+function advanceOrFinish(state: ComedyState): ActionResult<ComedyState, ComedyAction> {
+  if (state.round >= state.config.maxRounds) {
+    return {
+      state: { ...state, phase: 'finished' },
+      deadline: null,
+      progressIncrement: true,
+    };
+  }
+
+  return {
+    state: startRound(state),
+    deadline: {
+      seconds: state.config.turnTimerSeconds,
+      action: { type: 'round_timeout' },
+    },
+    progressIncrement: true,
+  };
+}
+
+export function createInitialState(config: ComedyConfig): ComedyState {
+  const regions = getBaseRegions();
+  return {
+    round: 0,
+    phase: 'waiting',
+    players: createPlayers(config.playerIds, regions),
+    regions,
+    ecosystems: getBaseEcosystems(),
+    activeTrades: [],
+    submittedActions: makeSubmittedActions(config.playerIds),
+    winner: null,
+    config,
+  };
+}
+
+export function validateAction(state: ComedyState, playerId: string | null, action: ComedyAction): boolean {
+  if (action.type === 'game_start') {
+    return playerId === null && state.phase === 'waiting';
+  }
+
+  if (action.type === 'round_timeout') {
+    return playerId === null && state.phase === 'playing';
+  }
+
+  if (playerId === null || state.phase !== 'playing') return false;
+  if (state.submittedActions[playerId] !== null) return false;
+  const player = state.players.find((item) => item.id === playerId);
+  if (!player) return false;
+
+  if (action.type === 'build_settlement') {
+    return Boolean(action.regionId && !player.regionsControlled.includes(action.regionId));
+  }
+
+  if (action.type === 'extract_commons') {
+    return Boolean(action.ecosystemId && EXTRACTION_PROFILES[action.level]);
+  }
+
+  return true;
+}
+
+export function applyAction(state: ComedyState, playerId: string | null, action: ComedyAction): ActionResult<ComedyState, ComedyAction> {
+  if (action.type === 'game_start') {
+    return {
+      state: startRound(state),
+      deadline: {
+        seconds: state.config.turnTimerSeconds,
+        action: { type: 'round_timeout' },
+      },
+      progressIncrement: true,
+    };
+  }
+
+  if (action.type === 'round_timeout') {
+    const completed = resolveRound({
+      ...state,
+      submittedActions: Object.fromEntries(
+        Object.entries(state.submittedActions).map(([id, submitted]) => [id, submitted ?? { type: 'pass' }]),
+      ),
+    });
+    return advanceOrFinish(completed);
+  }
+
+  if (!playerId) {
+    return { state };
+  }
+
+  const nextState: ComedyState = {
+    ...state,
+    submittedActions: {
+      ...state.submittedActions,
+      [playerId]: action,
+    },
+  };
+
+  if (!allPlayersSubmitted(nextState)) {
+    return { state: nextState };
+  }
+
+  const completed = resolveRound(nextState);
+  return advanceOrFinish(completed);
+}
+
+export interface ComedyPlayerView {
+  round: number;
+  maxRounds: number;
+  phase: ComedyState['phase'];
+  you: ComedyPlayerState;
+  scoreboard: Array<{ id: string; vp: number; influence: number; regionsControlled: number }>;
+  regions: ComedyRegion[];
+  ecosystems: Array<ComedyEcosystem & { status: ReturnType<typeof ecosystemStatus> }>;
+  activeTrades: ComedyTradeOffer[];
+  submitted: boolean;
+}
+
+export interface ComedySpectatorView {
+  round: number;
+  maxRounds: number;
+  phase: ComedyState['phase'];
+  players: Array<ComedyPlayerState & { totalResources: number }>;
+  regions: ComedyRegion[];
+  ecosystems: Array<ComedyEcosystem & { status: ReturnType<typeof ecosystemStatus> }>;
+  activeTrades: ComedyTradeOffer[];
+  winner: string | null;
+  handles: Record<string, string>;
+  relayMessages?: any[];
+}
+
+export function getPlayerView(state: ComedyState, playerId: string): ComedyPlayerView | null {
+  const player = state.players.find((item) => item.id === playerId);
+  if (!player) return null;
+  return {
+    round: state.round,
+    maxRounds: state.config.maxRounds,
+    phase: state.phase,
+    you: { ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] },
+    scoreboard: state.players.map((item) => ({
+      id: item.id,
+      vp: item.vp,
+      influence: item.influence,
+      regionsControlled: item.regionsControlled.length,
+    })),
+    regions: state.regions.map((region) => ({ ...region, secondaryResources: [...region.secondaryResources], ecosystemIds: [...region.ecosystemIds] })),
+    ecosystems: state.ecosystems.map((ecosystem) => ({ ...ecosystem, regionIds: [...ecosystem.regionIds], status: ecosystemStatus(ecosystem) })),
+    activeTrades: state.activeTrades.map((offer) => ({ ...offer, give: { ...offer.give }, receive: { ...offer.receive } })),
+    submitted: state.submittedActions[playerId] !== null,
+  };
+}
+
+export function getSpectatorView(state: ComedyState, handles: Record<string, string>, relayMessages: any[] = []): ComedySpectatorView {
+  return {
+    round: state.round,
+    maxRounds: state.config.maxRounds,
+    phase: state.phase,
+    players: state.players.map((player) => ({
+      ...player,
+      resources: cloneResources(player.resources),
+      regionsControlled: [...player.regionsControlled],
+      totalResources: totalResources(player.resources),
+    })),
+    regions: state.regions.map((region) => ({ ...region, secondaryResources: [...region.secondaryResources], ecosystemIds: [...region.ecosystemIds] })),
+    ecosystems: state.ecosystems.map((ecosystem) => ({ ...ecosystem, regionIds: [...ecosystem.regionIds], status: ecosystemStatus(ecosystem) })),
+    activeTrades: state.activeTrades.map((offer) => ({ ...offer, give: { ...offer.give }, receive: { ...offer.receive } })),
+    winner: state.winner,
+    handles,
+    relayMessages,
+  };
+}
+
+export function getOutcome(state: ComedyState): ComedyOutcome {
+  const rankings = [...state.players]
+    .sort((left, right) => {
+      if (right.vp !== left.vp) return right.vp - left.vp;
+      return right.influence - left.influence;
+    })
+    .map((player) => ({ id: player.id, vp: player.vp, influence: player.influence }));
+
+  return {
+    rankings,
+    roundsPlayed: state.round,
+    flourishingEcosystems: state.ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'flourishing').length,
+    collapsedEcosystems: state.ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'collapsed').length,
+  };
+}

--- a/packages/games/comedy-of-the-commons/src/game.ts
+++ b/packages/games/comedy-of-the-commons/src/game.ts
@@ -13,6 +13,14 @@ import {
   type ResourceType,
 } from './types.js';
 
+function toTradeOffer(action: Extract<ComedyAction, { type: 'offer_trade' }>): ComedyTradeOffer {
+  return {
+    to: action.to,
+    give: { ...action.give },
+    receive: { ...action.receive },
+  };
+}
+
 const RESOURCE_CAP = 14;
 const SETTLEMENT_COST: Partial<ResourceInventory> = {
   grain: 1,
@@ -203,28 +211,28 @@ function resolveTrades(
       const other = submittedByPlayer[j];
       if (other.action.type !== 'offer_trade' || used.has(j)) continue;
       if (current.playerId === other.playerId) continue;
-      if (current.action.offer.to !== other.playerId) continue;
-      if (other.action.offer.to !== current.playerId) continue;
-      if (!inventoryEquals(current.action.offer.give, other.action.offer.receive)) continue;
-      if (!inventoryEquals(current.action.offer.receive, other.action.offer.give)) continue;
+      if (current.action.to !== other.playerId) continue;
+      if (other.action.to !== current.playerId) continue;
+      if (!inventoryEquals(current.action.give, other.action.receive)) continue;
+      if (!inventoryEquals(current.action.receive, other.action.give)) continue;
 
       const actionSender = playerMap.get(current.playerId);
       const otherSender = playerMap.get(other.playerId);
       if (!actionSender || !otherSender) continue;
-      if (!canAfford(actionSender.resources, current.action.offer.give)) continue;
-      if (!canAfford(otherSender.resources, other.action.offer.give)) continue;
+      if (!canAfford(actionSender.resources, current.action.give)) continue;
+      if (!canAfford(otherSender.resources, other.action.give)) continue;
 
-      deductCost(actionSender.resources, current.action.offer.give);
-      deductCost(otherSender.resources, other.action.offer.give);
-      for (const [resource, amount] of Object.entries(current.action.offer.receive)) {
+      deductCost(actionSender.resources, current.action.give);
+      deductCost(otherSender.resources, other.action.give);
+      for (const [resource, amount] of Object.entries(current.action.receive)) {
         actionSender.resources[resource as ResourceType] += amount ?? 0;
       }
-      for (const [resource, amount] of Object.entries(other.action.offer.receive)) {
+      for (const [resource, amount] of Object.entries(other.action.receive)) {
         otherSender.resources[resource as ResourceType] += amount ?? 0;
       }
       actionSender.influence += 1;
       otherSender.influence += 1;
-      completed.push(current.action.offer, other.action.offer);
+      completed.push(toTradeOffer(current.action), toTradeOffer(other.action));
       used.add(i);
       used.add(j);
       break;
@@ -358,6 +366,10 @@ export function validateAction(state: ComedyState, playerId: string | null, acti
 
   if (action.type === 'extract_commons') {
     return Boolean(action.ecosystemId && EXTRACTION_PROFILES[action.level]);
+  }
+
+  if (action.type === 'offer_trade') {
+    return Boolean(action.to && action.to !== playerId);
   }
 
   return true;

--- a/packages/games/comedy-of-the-commons/src/index.ts
+++ b/packages/games/comedy-of-the-commons/src/index.ts
@@ -1,0 +1,26 @@
+export type {
+  ComedyAction,
+  ComedyConfig,
+  ComedyEcosystem,
+  ComedyOutcome,
+  ComedyPhase,
+  ComedyPlayerRanking,
+  ComedyPlayerState,
+  ComedyRegion,
+  ComedyState,
+  ComedyTradeOffer,
+  EcosystemKind,
+  ExtractionLevel,
+  ResourceInventory,
+  ResourceType,
+} from './types.js';
+
+export { DEFAULT_COMEDY_CONFIG, EMPTY_INVENTORY } from './types.js';
+export {
+  applyAction,
+  createInitialState,
+  getOutcome,
+  getPlayerView,
+  getSpectatorView,
+} from './game.js';
+export { ComedyOfTheCommonsPlugin } from './plugin.js';

--- a/packages/games/comedy-of-the-commons/src/index.ts
+++ b/packages/games/comedy-of-the-commons/src/index.ts
@@ -23,4 +23,4 @@ export {
   getPlayerView,
   getSpectatorView,
 } from './game.js';
-export { ComedyOfTheCommonsPlugin } from './plugin.js';
+export { ComedyOfTheCommonsPlugin, COMEDY_SYSTEM_ACTION_TYPES } from './plugin.js';

--- a/packages/games/comedy-of-the-commons/src/plugin.ts
+++ b/packages/games/comedy-of-the-commons/src/plugin.ts
@@ -1,0 +1,137 @@
+import type { CoordinationGame, GameSetup, SpectatorContext } from '@coordination-games/engine';
+import { OpenQueuePhase, registerGame } from '@coordination-games/engine';
+import {
+  DEFAULT_COMEDY_CONFIG,
+  type ComedyAction,
+  type ComedyConfig,
+  type ComedyOutcome,
+  type ComedyState,
+} from './types.js';
+import {
+  applyAction,
+  createInitialState,
+  getOutcome,
+  getPlayerView,
+  getSpectatorView,
+  validateAction,
+} from './game.js';
+
+const COMEDY_GUIDE = `# Comedy of the Commons — v0 Rules
+
+Comedy of the Commons is a free-for-all coordination game about shared scarcity.
+
+## Core loop
+- Each round begins with resource production from the regions you control.
+- You may submit one action per round.
+- Commons ecosystems can be extracted for short-term gain, but overuse degrades them.
+- You can expand by building settlements in unclaimed regions.
+- You can offer bilateral trades; reciprocal offers in the same round settle automatically.
+
+## Action types
+- \`offer_trade\`
+- \`extract_commons\`
+- \`build_settlement\`
+- \`pass\`
+
+## Win condition
+Highest VP wins when the round limit is reached. Influence is the tie-breaker.
+
+## Notes
+This is an intentionally reduced v0 upstream port. Richer trust, commitments, and Olympiad portability are planned for later slices.
+`;
+
+export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyState, ComedyAction, ComedyOutcome> = {
+  gameType: 'comedy-of-the-commons',
+  version: '0.1.0',
+  entryCost: 1,
+  spectatorDelay: 0,
+  guide: COMEDY_GUIDE,
+
+  lobby: {
+    queueType: 'open' as const,
+    phases: [new OpenQueuePhase(4)],
+    matchmaking: {
+      minPlayers: 4,
+      maxPlayers: 6,
+      teamSize: 1,
+      numTeams: 0,
+      queueTimeoutMs: 300000,
+    },
+  },
+
+  requiredPlugins: ['basic-chat'],
+  recommendedPlugins: ['rationale'],
+
+  createInitialState,
+
+  validateAction,
+
+  applyAction,
+
+  getVisibleState(state: ComedyState, playerId: string | null): unknown {
+    if (playerId === null) return getSpectatorView(state, {});
+    return getPlayerView(state, playerId) ?? getSpectatorView(state, {});
+  },
+
+  buildSpectatorView(state: ComedyState, _prevState: ComedyState | null, context: SpectatorContext): unknown {
+    return getSpectatorView(state, context.handles, context.relayMessages);
+  },
+
+  isOver(state: ComedyState): boolean {
+    return state.phase === 'finished';
+  },
+
+  getOutcome,
+
+  computePayouts(outcome: ComedyOutcome, playerIds: string[]): Map<string, number> {
+    const payouts = new Map<string, number>();
+    const topVp = outcome.rankings[0]?.vp ?? 0;
+    const winners = outcome.rankings.filter((ranking) => ranking.vp === topVp);
+    const winnerPayout = playerIds.length / Math.max(1, winners.length);
+    for (const id of playerIds) {
+      payouts.set(id, winners.some((winner) => winner.id === id) ? winnerPayout - 1 : -1);
+    }
+    return payouts;
+  },
+
+  getPlayerStatus(state: ComedyState, playerId: string): string {
+    const player = state.players.find((item) => item.id === playerId);
+    if (!player) return '\n## Your Status\n- Unknown player';
+    return `\n## Your Status\n- **Phase:** ${state.phase}\n- **Round:** ${state.round}/${state.config.maxRounds}\n- **VP:** ${player.vp}\n- **Influence:** ${player.influence}\n- **Controlled Regions:** ${player.regionsControlled.length}`;
+  },
+
+  getSummary(state: ComedyState): Record<string, any> {
+    return {
+      round: state.round,
+      maxRounds: state.config.maxRounds,
+      phase: state.phase,
+      players: state.players.map((player) => player.id),
+      flourishingEcosystems: state.ecosystems.filter((ecosystem) => ecosystem.health >= ecosystem.flourishThreshold).length,
+    };
+  },
+
+  getPlayersNeedingAction(state: ComedyState): string[] {
+    if (state.phase !== 'playing') return [];
+    return state.players
+      .filter((player) => state.submittedActions[player.id] === null)
+      .map((player) => player.id);
+  },
+
+  createConfig(
+    players: { id: string; handle: string; team?: string; role?: string }[],
+    seed: string,
+    options?: Record<string, any>,
+  ): GameSetup<ComedyConfig> {
+    return {
+      config: {
+        ...DEFAULT_COMEDY_CONFIG,
+        playerIds: players.map((player) => player.id),
+        seed,
+        ...(options?.maxRounds ? { maxRounds: options.maxRounds } : {}),
+      },
+      players: players.map((player) => ({ id: player.id, team: 'FFA' })),
+    };
+  },
+};
+
+registerGame(ComedyOfTheCommonsPlugin);

--- a/packages/games/comedy-of-the-commons/src/plugin.ts
+++ b/packages/games/comedy-of-the-commons/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { CoordinationGame, GameSetup, SpectatorContext } from '@coordination-games/engine';
+import type { CoordinationGame, GameSetup, SpectatorContext, ToolDefinition } from '@coordination-games/engine';
 import { OpenQueuePhase, registerGame } from '@coordination-games/engine';
 import {
   DEFAULT_COMEDY_CONFIG,
@@ -40,6 +40,66 @@ Highest VP wins when the round limit is reached. Influence is the tie-breaker.
 This is an intentionally reduced v0 upstream port. Richer trust, commitments, and Olympiad portability are planned for later slices.
 `;
 
+export const COMEDY_SYSTEM_ACTION_TYPES: readonly string[] = Object.freeze([
+  'game_start',
+  'round_timeout',
+]);
+
+const GAME_TOOLS: ToolDefinition[] = [
+  {
+    name: 'offer_trade',
+    description: 'Offer a bilateral trade to one other player. Matching reciprocal offers in the same round settle automatically.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Target player id for the trade offer.' },
+        give: { type: 'object', description: 'Resources you are offering.' },
+        receive: { type: 'object', description: 'Resources you want back.' },
+      },
+      required: ['to', 'give', 'receive'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'extract_commons',
+    description: 'Extract a shared resource from an ecosystem you can access. Higher extraction gives more now but damages the commons faster.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ecosystemId: { type: 'string' },
+        level: { type: 'string', enum: ['low', 'medium', 'high'] },
+      },
+      required: ['ecosystemId', 'level'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'build_settlement',
+    description: 'Spend resources to establish a settlement in an unclaimed region and gain VP.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        regionId: { type: 'string' },
+      },
+      required: ['regionId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'pass',
+    description: 'Submit no action for this round.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];
+
 export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyState, ComedyAction, ComedyOutcome> = {
   gameType: 'comedy-of-the-commons',
   version: '0.1.0',
@@ -58,6 +118,8 @@ export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyStat
       queueTimeoutMs: 300000,
     },
   },
+
+  gameTools: GAME_TOOLS,
 
   requiredPlugins: ['basic-chat'],
   recommendedPlugins: ['rationale'],

--- a/packages/games/comedy-of-the-commons/src/types.ts
+++ b/packages/games/comedy-of-the-commons/src/types.ts
@@ -73,7 +73,7 @@ export interface ComedyTradeOffer {
 
 export type ComedyAction =
   | { type: 'game_start' }
-  | { type: 'offer_trade'; offer: ComedyTradeOffer }
+  | { type: 'offer_trade'; to: string; give: Partial<ResourceInventory>; receive: Partial<ResourceInventory> }
   | { type: 'extract_commons'; ecosystemId: string; level: ExtractionLevel }
   | { type: 'build_settlement'; regionId: string }
   | { type: 'pass' }

--- a/packages/games/comedy-of-the-commons/src/types.ts
+++ b/packages/games/comedy-of-the-commons/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Comedy of the Commons — initial upstream v0 type surface.
+ *
+ * These types intentionally describe the smallest believable upstream Comedy
+ * shape, not the full local arena prototype.
+ */
+
+export type ComedyPhase = 'waiting' | 'playing' | 'finished';
+
+export type ResourceType =
+  | 'grain'
+  | 'timber'
+  | 'ore'
+  | 'fish'
+  | 'water'
+  | 'energy';
+
+export interface ResourceInventory {
+  grain: number;
+  timber: number;
+  ore: number;
+  fish: number;
+  water: number;
+  energy: number;
+}
+
+export const EMPTY_INVENTORY: ResourceInventory = {
+  grain: 0,
+  timber: 0,
+  ore: 0,
+  fish: 0,
+  water: 0,
+  energy: 0,
+};
+
+export type EcosystemKind = 'fishery' | 'forest' | 'aquifer' | 'wetland';
+
+export type ExtractionLevel = 'low' | 'medium' | 'high';
+
+export interface ComedyRegion {
+  id: string;
+  name: string;
+  primaryResource: ResourceType;
+  secondaryResources: ResourceType[];
+  ecosystemIds: string[];
+}
+
+export interface ComedyEcosystem {
+  id: string;
+  name: string;
+  kind: EcosystemKind;
+  resource: ResourceType;
+  regionIds: string[];
+  health: number;
+  maxHealth: number;
+  collapseThreshold: number;
+  flourishThreshold: number;
+}
+
+export interface ComedyPlayerState {
+  id: string;
+  resources: ResourceInventory;
+  influence: number;
+  vp: number;
+  regionsControlled: string[];
+}
+
+export interface ComedyTradeOffer {
+  to: string;
+  give: Partial<ResourceInventory>;
+  receive: Partial<ResourceInventory>;
+}
+
+export type ComedyAction =
+  | { type: 'game_start' }
+  | { type: 'offer_trade'; offer: ComedyTradeOffer }
+  | { type: 'extract_commons'; ecosystemId: string; level: ExtractionLevel }
+  | { type: 'build_settlement'; regionId: string }
+  | { type: 'pass' }
+  | { type: 'round_timeout' };
+
+export interface ComedyConfig {
+  seed: string;
+  playerIds: string[];
+  maxRounds: number;
+  turnTimerSeconds: number;
+}
+
+export interface ComedyState {
+  round: number;
+  phase: ComedyPhase;
+  players: ComedyPlayerState[];
+  regions: ComedyRegion[];
+  ecosystems: ComedyEcosystem[];
+  activeTrades: ComedyTradeOffer[];
+  submittedActions: Record<string, ComedyAction | null>;
+  winner: string | null;
+  config: ComedyConfig;
+}
+
+export interface ComedyPlayerRanking {
+  id: string;
+  vp: number;
+  influence: number;
+}
+
+export interface ComedyOutcome {
+  rankings: ComedyPlayerRanking[];
+  roundsPlayed: number;
+  flourishingEcosystems: number;
+  collapsedEcosystems: number;
+}
+
+export const DEFAULT_COMEDY_CONFIG: ComedyConfig = {
+  seed: 'comedy-v0',
+  playerIds: [],
+  maxRounds: 12,
+  turnTimerSeconds: 60,
+};

--- a/packages/games/comedy-of-the-commons/tsconfig.json
+++ b/packages/games/comedy-of-the-commons/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"],
+  "references": [
+    { "path": "../../engine" }
+  ]
+}

--- a/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
+++ b/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
@@ -54,14 +54,16 @@ function statusColor(status: ComedyEcosystem['status']): string {
 }
 
 export function ComedySpectatorView(props: SpectatorViewProps) {
-  const { gameId, handles, chatMessages } = props;
+  const { gameId, handles, chatMessages, gameState } = props;
   const [state, setState] = useState<ComedySpectatorState | null>(null);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const replayState = mapServerState(gameState);
+  const effectiveState = replayState ?? state;
 
   useEffect(() => {
-    if (!gameId) return;
+    if (!gameId || replayState) return;
 
     fetch(`${API_BASE}/games/${gameId}`)
       .then((r) => r.json())
@@ -89,14 +91,14 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
       ws.close();
       wsRef.current = null;
     };
-  }, [gameId]);
+  }, [gameId, replayState]);
 
   const sortedPlayers = useMemo(
-    () => [...(state?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
-    [state?.players],
+    () => [...(effectiveState?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
+    [effectiveState?.players],
   );
 
-  if (!state) {
+  if (!effectiveState) {
     return (
       <div className="flex h-[calc(100vh-5rem)] items-center justify-center px-6 text-center">
         <div>
@@ -114,10 +116,10 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-emerald-200">Comedy of the Commons</h1>
-              <p className="text-sm text-slate-400">Round {state.round}/{state.maxRounds} · {state.phase}</p>
+              <p className="text-sm text-slate-400">Round {effectiveState.round}/{effectiveState.maxRounds} · {effectiveState.phase}</p>
             </div>
             <div className="rounded-full border border-emerald-500/20 px-3 py-1 text-xs uppercase tracking-[0.2em] text-emerald-300">
-              {state.winner ? `Leader: ${handles[state.winner] ?? state.winner}` : 'Live commons race'}
+              {effectiveState.winner ? `Leader: ${handles[effectiveState.winner] ?? effectiveState.winner}` : 'Live commons race'}
             </div>
           </div>
 
@@ -154,7 +156,7 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
           <section className="rounded-2xl border border-sky-500/20 bg-slate-900/80 p-5 shadow-xl">
             <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Ecosystems</h2>
             <div className="space-y-3">
-              {state.ecosystems.map((ecosystem) => {
+              {effectiveState.ecosystems.map((ecosystem) => {
                 const pct = Math.max(0, Math.min(100, Math.round((ecosystem.health / ecosystem.maxHealth) * 100)));
                 return (
                   <div key={ecosystem.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
@@ -177,11 +179,11 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
 
           <section className="rounded-2xl border border-amber-500/20 bg-slate-900/80 p-5 shadow-xl">
             <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Active trades</h2>
-            {state.activeTrades.length === 0 ? (
+            {effectiveState.activeTrades.length === 0 ? (
               <p className="text-sm text-slate-400">No reciprocal trades settled this round.</p>
             ) : (
               <div className="space-y-2 text-sm text-slate-300">
-                {state.activeTrades.map((trade, index) => (
+                {effectiveState.activeTrades.map((trade, index) => (
                   <div key={`${trade.to}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
                     <div className="text-xs uppercase tracking-[0.14em] text-slate-500">to {handles[trade.to] ?? trade.to}</div>
                     <div>Give {JSON.stringify(trade.give)} · Receive {JSON.stringify(trade.receive)}</div>

--- a/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
+++ b/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { SpectatorViewProps } from '../types';
+import { API_BASE, getWsUrl } from '../../config.js';
+
+interface ComedyPlayer {
+  id: string;
+  vp: number;
+  influence: number;
+  totalResources: number;
+  resources: Record<string, number>;
+  regionsControlled: string[];
+}
+
+interface ComedyEcosystem {
+  id: string;
+  name: string;
+  resource: string;
+  health: number;
+  maxHealth: number;
+  status: 'flourishing' | 'stable' | 'strained' | 'collapsed';
+}
+
+interface ComedySpectatorState {
+  round: number;
+  maxRounds: number;
+  phase: 'waiting' | 'playing' | 'finished';
+  winner: string | null;
+  players: ComedyPlayer[];
+  ecosystems: ComedyEcosystem[];
+  activeTrades: Array<{ to: string; give: Record<string, number>; receive: Record<string, number> }>;
+}
+
+function mapServerState(raw: any): ComedySpectatorState | null {
+  const data = raw?.data ?? raw;
+  if (!data?.players || !Array.isArray(data.players) || !Array.isArray(data.ecosystems)) return null;
+  return {
+    round: data.round ?? 0,
+    maxRounds: data.maxRounds ?? data.config?.maxRounds ?? 12,
+    phase: data.phase ?? 'waiting',
+    winner: data.winner ?? null,
+    players: data.players,
+    ecosystems: data.ecosystems,
+    activeTrades: data.activeTrades ?? [],
+  };
+}
+
+function statusColor(status: ComedyEcosystem['status']): string {
+  switch (status) {
+    case 'flourishing': return '#7bd88f';
+    case 'strained': return '#f6c177';
+    case 'collapsed': return '#ef6b73';
+    default: return '#8ecae6';
+  }
+}
+
+export function ComedySpectatorView(props: SpectatorViewProps) {
+  const { gameId, handles, chatMessages } = props;
+  const [state, setState] = useState<ComedySpectatorState | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    fetch(`${API_BASE}/games/${gameId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const mapped = mapServerState(data);
+        if (mapped) setState(mapped);
+      })
+      .catch(() => setError('Failed to load Comedy game state'));
+
+    const ws = new WebSocket(getWsUrl(`/ws/game/${gameId}`));
+    wsRef.current = ws;
+    ws.onopen = () => { setConnected(true); setError(null); };
+    ws.onclose = () => setConnected(false);
+    ws.onerror = () => setError('WebSocket error');
+    ws.onmessage = (event) => {
+      try {
+        const mapped = mapServerState(JSON.parse(event.data));
+        if (mapped) setState(mapped);
+      } catch {
+        // Ignore malformed spectator updates.
+      }
+    };
+
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [gameId]);
+
+  const sortedPlayers = useMemo(
+    () => [...(state?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
+    [state?.players],
+  );
+
+  if (!state) {
+    return (
+      <div className="flex h-[calc(100vh-5rem)] items-center justify-center px-6 text-center">
+        <div>
+          <div className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-emerald-300">Comedy of the Commons</div>
+          <p className="text-sm text-slate-300">{error ?? (connected ? 'Waiting for game state…' : 'Connecting…')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-5rem)] bg-slate-950 px-6 py-6 text-slate-100">
+      <div className="mx-auto grid max-w-7xl gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-2xl border border-emerald-500/20 bg-slate-900/80 p-5 shadow-xl">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-emerald-200">Comedy of the Commons</h1>
+              <p className="text-sm text-slate-400">Round {state.round}/{state.maxRounds} · {state.phase}</p>
+            </div>
+            <div className="rounded-full border border-emerald-500/20 px-3 py-1 text-xs uppercase tracking-[0.2em] text-emerald-300">
+              {state.winner ? `Leader: ${handles[state.winner] ?? state.winner}` : 'Live commons race'}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {sortedPlayers.map((player) => {
+              const name = handles[player.id] ?? player.id;
+              return (
+                <article key={player.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <div>
+                      <h2 className="font-medium text-emerald-100">{name}</h2>
+                      <p className="text-xs uppercase tracking-[0.18em] text-slate-500">{player.regionsControlled.length} regions · {player.totalResources} resources</p>
+                    </div>
+                    <div className="text-right text-xs text-slate-300">
+                      <div>VP {player.vp}</div>
+                      <div>Inf {player.influence}</div>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2 text-xs text-slate-300">
+                    {Object.entries(player.resources).map(([resource, amount]) => (
+                      <div key={resource} className="rounded-lg bg-slate-900/80 px-2 py-1">
+                        <div className="uppercase tracking-[0.12em] text-slate-500">{resource}</div>
+                        <div className="font-medium text-slate-100">{amount}</div>
+                      </div>
+                    ))}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <aside className="space-y-6">
+          <section className="rounded-2xl border border-sky-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Ecosystems</h2>
+            <div className="space-y-3">
+              {state.ecosystems.map((ecosystem) => {
+                const pct = Math.max(0, Math.min(100, Math.round((ecosystem.health / ecosystem.maxHealth) * 100)));
+                return (
+                  <div key={ecosystem.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+                    <div className="mb-2 flex items-center justify-between gap-2 text-sm">
+                      <span className="font-medium text-slate-100">{ecosystem.name}</span>
+                      <span className="text-xs uppercase tracking-[0.18em]" style={{ color: statusColor(ecosystem.status) }}>{ecosystem.status}</span>
+                    </div>
+                    <div className="mb-2 h-2 rounded-full bg-slate-800">
+                      <div className="h-2 rounded-full" style={{ width: `${pct}%`, background: statusColor(ecosystem.status) }} />
+                    </div>
+                    <div className="flex items-center justify-between text-xs text-slate-400">
+                      <span>{ecosystem.resource}</span>
+                      <span>{ecosystem.health}/{ecosystem.maxHealth}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-amber-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Active trades</h2>
+            {state.activeTrades.length === 0 ? (
+              <p className="text-sm text-slate-400">No reciprocal trades settled this round.</p>
+            ) : (
+              <div className="space-y-2 text-sm text-slate-300">
+                {state.activeTrades.map((trade, index) => (
+                  <div key={`${trade.to}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
+                    <div className="text-xs uppercase tracking-[0.14em] text-slate-500">to {handles[trade.to] ?? trade.to}</div>
+                    <div>Give {JSON.stringify(trade.give)} · Receive {JSON.stringify(trade.receive)}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-violet-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-violet-300">Public chat</h2>
+            <div className="space-y-2 text-sm text-slate-300">
+              {chatMessages.length === 0 ? (
+                <p className="text-slate-400">No public messages yet.</p>
+              ) : (
+                chatMessages.slice(-8).map((message, index) => (
+                  <div key={`${message.timestamp}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
+                    <div className="mb-1 text-xs uppercase tracking-[0.14em] text-slate-500">{handles[message.from] ?? message.from}</div>
+                    <div>{message.message}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/games/comedy-of-the-commons/index.ts
+++ b/packages/web/src/games/comedy-of-the-commons/index.ts
@@ -1,0 +1,9 @@
+import type { SpectatorPlugin } from '../types';
+import { ComedySpectatorView } from './SpectatorView';
+
+export const ComedyOfTheCommonsSpectator: SpectatorPlugin = {
+  gameType: 'comedy-of-the-commons',
+  displayName: 'Comedy of the Commons',
+  SpectatorView: ComedySpectatorView,
+  animationDuration: 1200,
+};

--- a/packages/web/src/games/registry.ts
+++ b/packages/web/src/games/registry.ts
@@ -1,8 +1,10 @@
 import type { SpectatorPlugin } from './types';
+import { ComedyOfTheCommonsSpectator } from './comedy-of-the-commons';
 import { CaptureTheLobsterSpectator } from './capture-the-lobster';
 import { OathbreakerSpectator } from './oathbreaker';
 
 const SPECTATOR_PLUGINS: Record<string, SpectatorPlugin> = {
+  'comedy-of-the-commons': ComedyOfTheCommonsSpectator,
   'capture-the-lobster': CaptureTheLobsterSpectator,
   'oathbreaker': OathbreakerSpectator,
 };

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -61,8 +61,9 @@ export default function LobbiesPage() {
   const [lobbies, setLobbies] = useState<Lobby[]>([]);
   const [creating, setCreating] = useState(false);
   const [teamSize, setTeamSize] = useState(2);
-  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker'>('capture-the-lobster');
+  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker' | 'comedy-of-the-commons'>('capture-the-lobster');
   const [oathPlayerCount, setOathPlayerCount] = useState(4);
+  const [comedyPlayerCount, setComedyPlayerCount] = useState(4);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -104,6 +105,12 @@ export default function LobbiesPage() {
         const res = await fetch(`${API_BASE}/lobbies/create`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ gameType: 'oathbreaker', playerCount: oathPlayerCount }),
+        });
+        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
+      } else if (gameTab === 'comedy-of-the-commons') {
+        const res = await fetch(`${API_BASE}/lobbies/create`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ gameType: 'comedy-of-the-commons', teamSize: comedyPlayerCount }),
         });
         if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
       } else {
@@ -148,6 +155,16 @@ export default function LobbiesPage() {
           >
             OATHBREAKER
           </button>
+          <button
+            onClick={() => setGameTab('comedy-of-the-commons')}
+            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
+            style={gameTab === 'comedy-of-the-commons'
+              ? { background: 'rgba(16, 185, 129, 0.12)', color: '#86efac', border: '1px solid rgba(16, 185, 129, 0.35)' }
+              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+            }
+          >
+            Comedy of the Commons
+          </button>
         </div>
 
         {/* Create controls */}
@@ -168,7 +185,7 @@ export default function LobbiesPage() {
                 </button>
               ))}
             </div>
-          ) : (
+          ) : gameTab === 'oathbreaker' ? (
             <div className="flex items-center gap-2">
               <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
               {[4, 6, 8, 10, 12, 16, 20].map((count) => (
@@ -178,6 +195,23 @@ export default function LobbiesPage() {
                   className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
                   style={oathPlayerCount === count
                     ? { background: 'rgba(139, 32, 32, 0.15)', color: 'var(--color-blood-light, #c55)', border: '1px solid rgba(139, 32, 32, 0.4)' }
+                    : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+                  }
+                >
+                  {count}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
+              {[4, 5, 6].map((count) => (
+                <button
+                  key={count}
+                  onClick={() => setComedyPlayerCount(count)}
+                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
+                  style={comedyPlayerCount === count
+                    ? { background: 'rgba(16, 185, 129, 0.15)', color: '#86efac', border: '1px solid rgba(16, 185, 129, 0.4)' }
                     : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
                   }
                 >
@@ -312,12 +346,58 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
         {gameType === 'oathbreaker' && (
           <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>OATHBREAKER</span>
         )}
+        {gameType === 'comedy-of-the-commons' && (
+          <span className="font-heading text-xs font-medium" style={{ color: '#86efac' }}>COMEDY</span>
+        )}
       </div>
     </button>
   );
 }
 
 function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
+  if (game.gameType === 'comedy-of-the-commons') {
+    const round = game.round ?? game.turn ?? 0;
+    const maxRounds = game.maxRounds ?? game.maxTurns ?? 12;
+    const progress = maxRounds > 0 ? Math.round((round / maxRounds) * 100) : 0;
+    const isLive = game.phase === 'playing' || game.phase === 'in_progress';
+    return (
+      <button onClick={onClick} className="group cursor-pointer w-full rounded-xl parchment-strong p-5 text-left transition-all duration-200 hover:shadow-md">
+        <div className="mb-3 flex items-center justify-between">
+          <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>{game.id}</span>
+          {phaseBadge(isLive ? 'in_progress' : game.phase === 'finished' ? 'finished' : 'starting')}
+        </div>
+        <div className="mb-3">
+          <div className="mb-1.5 flex justify-between text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>
+            <span>Round {round}/{maxRounds}</span>
+            <span>{progress}%</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full" style={{ background: 'rgba(42, 31, 14, 0.08)' }}>
+            <motion.div
+              className="h-1.5 rounded-full"
+              style={{
+                width: `${progress}%`,
+                background: isLive
+                  ? 'linear-gradient(90deg, #10b981, #86efac)'
+                  : 'linear-gradient(90deg, var(--color-ink-faint), var(--color-wood-light))',
+              }}
+              initial={{ width: 0 }}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 0.8, ease: 'easeOut' }}
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-heading text-xs font-medium" style={{ color: '#86efac' }}>
+            Comedy of the Commons
+          </span>
+          <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>
+            {game.playerCount ?? '?'} players
+          </span>
+        </div>
+      </button>
+    );
+  }
+
   // OATHBREAKER game card
   if (game.gameType === 'oathbreaker') {
     const round = game.round ?? game.turn ?? 0;

--- a/packages/workers-server/package.json
+++ b/packages/workers-server/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250407.0",
     "@coordination-games/engine": "*",
+    "@coordination-games/game-comedy-of-the-commons": "*",
     "@coordination-games/game-ctl": "*",
     "@coordination-games/game-oathbreaker": "*",
     "ajv": "^8.17.1",

--- a/packages/workers-server/src/do/GameRoomDO.ts
+++ b/packages/workers-server/src/do/GameRoomDO.ts
@@ -29,6 +29,7 @@ import type { CoordinationGame, MerkleLeafData } from '@coordination-games/engin
 import type { Env } from '../env.js';
 
 // Side-effect imports: each calls registerGame() on module load
+import '@coordination-games/game-comedy-of-the-commons';
 import '@coordination-games/game-ctl';
 import '@coordination-games/game-oathbreaker';
 
@@ -669,6 +670,7 @@ export class GameRoomDO extends DurableObject<Env> {
     // Fire-and-forget: catch all errors to prevent unhandled rejections
     (async () => {
       try {
+        await this.ensureGameRowInD1();
         await this.env.DB.prepare(
           `INSERT INTO game_summaries (game_id, progress_counter, summary_json, updated_at)
            VALUES (?1, ?2, ?3, datetime('now'))
@@ -704,6 +706,20 @@ export class GameRoomDO extends DurableObject<Env> {
       // Final catch-all to prevent unhandled rejections
       console.error(`[GameRoomDO] Unhandled error in writeSummaryToD1:`, err);
     });
+  }
+
+  /** Ensure the parent games row exists before summary writes that FK-reference it. */
+  private async ensureGameRowInD1(): Promise<void> {
+    if (!this._meta) return;
+    await this.env.DB.prepare(
+      `INSERT OR IGNORE INTO games (game_id, game_type, finished, created_at)
+       VALUES (?1, ?2, ?3, ?4)`
+    ).bind(
+      this._meta.gameId,
+      this._meta.gameType,
+      this._meta.finished ? 1 : 0,
+      this._meta.createdAt,
+    ).run();
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/workers-server/src/do/LobbyDO.ts
+++ b/packages/workers-server/src/do/LobbyDO.ts
@@ -31,6 +31,7 @@ import type {
 } from '@coordination-games/engine';
 
 // Side-effect imports — register game plugins with the engine registry
+import '@coordination-games/game-comedy-of-the-commons';
 import '@coordination-games/game-ctl';
 import '@coordination-games/game-oathbreaker';
 


### PR DESCRIPTION
# PR Notes — djimo/comedy-v0-lobby-path-r1

## Branch

- Branch: `djimo/comedy-v0-lobby-path-r1`
- PR URL: `https://github.com/coordination-games/coordination-games/pull/new/djimo/comedy-v0-lobby-path-r1`

## Purpose

Make the latest-main-compatible Comedy package **actually reachable and startable** through the current shell/lobby/replay path.

This branch is intentionally not a shell-neutralization branch. It accepts the current CtL-branded latest-main shell and closes the specific product gap: Comedy exists in runtime but was not enterable from the user-facing flow.

## What changed

- replays the refreshed Comedy package/runtime/spectator registration work on top of latest `origin/main`
- adds the minimal Comedy start-path patch to `packages/web/src/pages/LobbiesPage.tsx`
- exposes a third game tab: `Comedy of the Commons`
- adds Comedy-specific player count controls (`4`, `5`, `6`) and a `Create Lobby` path
- surfaces real Comedy recent game cards that route into `/replay/<gameId>`

## Verification completed

- local visual proof on latest-main recut branch:
  - `http://127.0.0.1:4176/lobbies`
  - switch to the Comedy tab
  - see Comedy-specific create controls
  - see real Comedy recent game cards backed by live worker data
  - click through to `/replay/<gameId>` and load a real Comedy spectator/replay view
- worker replay endpoint returned valid Comedy replay JSON for the surfaced game

## Review framing

Review this branch as a **bridge patch**: the smallest latest-main-compatible path that makes Comedy startable and replayable.

It is intentionally tactical and not yet the final generalized multi-game shell architecture.

## Known intentional debt

- `LobbiesPage.tsx` contains Comedy-specific hardcoding for the start path
- the shell remains CtL-branded on this branch
- this branch should not be mistaken for the final shell-neutral game discovery design

## Relationship to other branches

- depends conceptually on the package/runtime/tool-surface work in `djimo/comedy-v0-plugin-r2`
- should be reviewed as the **start-path complement** to that branch, not as a replacement for it
