### PR TITLE
feat(workers): add secret-gated bot auth test path

### DIFF
--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,6 +1,20 @@
 import { Command } from "commander";
 import crypto from "node:crypto";
 
+async function requestBotToken(serverUrl: string, name: string, secret?: string): Promise<string> {
+  const response = await fetch(`${serverUrl}/api/player/auth/bot`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, ...(secret ? { secret } : {}) }),
+  });
+
+  const data = await response.json() as { token?: string; error?: string };
+  if (!response.ok || !data.token) {
+    throw new Error(data.error || `Bot auth failed with status ${response.status}`);
+  }
+  return data.token;
+}
+
 export function registerServeCommand(program: Command) {
   program
     .command("serve")
@@ -10,6 +24,7 @@ export function registerServeCommand(program: Command) {
     .option("--bot-mode", undefined, false)  // hidden: internal testing
     .option("--key <key>", undefined)         // hidden: bot private key
     .option("--name <name>", undefined)       // hidden: bot display name
+    .option("--bot-secret <secret>", undefined) // hidden: shared secret for non-local bot token auth
     .option("--server-url <url>", "Game server URL (default: from config)")
     .action(async (opts) => {
       // Dynamic import to avoid loading MCP deps when not needed
@@ -24,10 +39,12 @@ export function registerServeCommand(program: Command) {
         const serverUrl = opts.serverUrl || loadConfig().serverUrl;
         const key = opts.key || undefined;
         const name = opts.name || `bot-${crypto.randomBytes(3).toString('hex')}`;
+        const token = key ? undefined : await requestBotToken(serverUrl, name, opts.botSecret || process.env.COGA_BOT_SECRET);
 
         await startMcpServer(mode, {
           serverUrl,
           privateKey: key,
+          token,
           name,
           botMode: true,
           httpPort,

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -21,6 +21,7 @@ import { BasicChatPlugin } from "@coordination-games/plugin-chat";
 export interface ServeOptions {
   serverUrl: string;
   privateKey?: string;
+  token?: string;
   name?: string;
   botMode?: boolean;
   httpPort?: number;
@@ -30,6 +31,7 @@ function createMcpServerWithClient(options?: ServeOptions): { server: McpServer;
   const serverUrl = options?.serverUrl || loadConfig().serverUrl;
   const client = new GameClient(serverUrl, {
     privateKey: options?.privateKey,
+    token: options?.token,
     name: options?.name,
   });
   const server = new McpServer({

--- a/packages/workers-server/.gitignore
+++ b/packages/workers-server/.gitignore
@@ -1,3 +1,5 @@
+.dev.vars
+.wrangler/cache/
 .wrangler/state/
 node_modules/
 dist/

--- a/packages/workers-server/src/auth.ts
+++ b/packages/workers-server/src/auth.ts
@@ -161,17 +161,75 @@ export async function handleAuthVerify(request: Request, env: Env): Promise<Resp
     throw err;
   }
 
-  // Issue session token
+  const { token, expiresAt } = await issueSessionToken(env, playerId, trimmed);
+
+  console.log(`[auth] Verified "${trimmed}" wallet=${address.toLowerCase()} playerId=${playerId} reconnected=${reconnected}`);
+
+  return Response.json({ token, agentId: playerId, name: trimmed, expiresAt, reconnected });
+}
+
+function deriveBotWalletAddress(name: string): `0x${string}` {
+  const normalized = name.trim().toLowerCase();
+  const digest = keccak256(toBytes(`bot:${normalized}`));
+  return `0x${digest.slice(-40)}` as `0x${string}`;
+}
+
+async function issueSessionToken(env: Env, playerId: string, name: string): Promise<{ token: string; expiresAt: string }> {
   const token = hexRandom(20);
   const expiresAt = new Date(Date.now() + SESSION_TTL_MS).toISOString();
 
   await env.DB.prepare(
     'INSERT OR REPLACE INTO auth_sessions (token, player_id, name, expires_at) VALUES (?, ?, ?, ?)'
-  ).bind(token, playerId, trimmed, expiresAt).run();
+  ).bind(token, playerId, name, expiresAt).run();
 
-  console.log(`[auth] Verified "${trimmed}" wallet=${address.toLowerCase()} playerId=${playerId} reconnected=${reconnected}`);
+  return { token, expiresAt };
+}
 
-  return Response.json({ token, agentId: playerId, name: trimmed, expiresAt, reconnected });
+// ---------------------------------------------------------------------------
+// POST /api/player/auth/bot
+// ---------------------------------------------------------------------------
+
+export async function handleBotAuth(request: Request, env: Env): Promise<Response> {
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json() as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const name = String(body?.name ?? '').trim();
+  const providedSecret = typeof body?.secret === 'string' ? body.secret : undefined;
+  if (!name) {
+    return Response.json({ error: 'name is required' }, { status: 400 });
+  }
+
+  const configuredSecret = env.TEST_BOT_AUTH_SECRET;
+  if (!configuredSecret) {
+    return Response.json({ error: 'bot auth is not configured in this environment' }, { status: 503 });
+  }
+
+  if (providedSecret !== configuredSecret) {
+    return Response.json({ error: 'invalid bot auth secret' }, { status: 403 });
+  }
+
+  const relay = createRelay(env);
+  const address = deriveBotWalletAddress(name);
+  let playerId: string;
+  let reconnected: boolean;
+
+  try {
+    const { player, created } = await resolvePlayer(address, relay, env.DB, { handle: name });
+    playerId = player.id;
+    reconnected = !created;
+  } catch (err) {
+    if (err instanceof PlayerHandleTakenError) {
+      return Response.json({ error: err.message }, { status: 409 });
+    }
+    throw err;
+  }
+
+  const { token, expiresAt } = await issueSessionToken(env, playerId, name);
+  return Response.json({ token, agentId: playerId, name, expiresAt, reconnected, bot: true, walletAddress: address });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workers-server/src/env.ts
+++ b/packages/workers-server/src/env.ts
@@ -3,6 +3,7 @@ export interface Env {
   GAME_ROOM: DurableObjectNamespace;
   LOBBY: DurableObjectNamespace;
   ENVIRONMENT: string;
+  TEST_BOT_AUTH_SECRET?: string;
   // Optional — set via `wrangler secret put` to enable on-chain ERC-8004 verification
   RPC_URL?: string;
   REGISTRY_ADDRESS?: string;

--- a/packages/workers-server/src/index.ts
+++ b/packages/workers-server/src/index.ts
@@ -1,6 +1,6 @@
 import { GameRoomDO } from './do/GameRoomDO.js';
 import { LobbyDO } from './do/LobbyDO.js';
-import { handleAuthChallenge, handleAuthVerify, validateBearerToken } from './auth.js';
+import { handleAuthChallenge, handleAuthVerify, handleBotAuth, validateBearerToken } from './auth.js';
 import { D1EloTracker } from './db/elo.js';
 import { getRegisteredGames, getGame } from '@coordination-games/engine';
 import { createRelay } from './chain/index.js';
@@ -89,6 +89,10 @@ async function handleRequest(request: Request, env: Env): Promise<Response> {
 
     if (pathname === '/api/player/auth/verify' && method === 'POST') {
       return handleAuthVerify(request, env);
+    }
+
+    if (pathname === '/api/player/auth/bot' && method === 'POST') {
+      return handleBotAuth(request, env);
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
# PR Notes — `djimo/bot-auth-test-path-r1`

## Branch

- Repo: `coordination-games`
- Branch: `djimo/bot-auth-test-path-r1`
- PR URL: `https://github.com/coordination-games/coordination-games/pull/new/djimo/bot-auth-test-path-r1`

## Suggested PR title

`Add secret-gated bot auth test path`

## Suggested PR summary

This branch adds a narrow, test-only platform path for server-issued bot tokens. It keeps the path secret-gated, reuses the existing auth session machinery, and lets `serve --bot-mode` run without a private key by obtaining a bearer token from the worker.

The intent is not to define the final bot-auth product, but to create one real platform-native bot path that uses the same `GameClient` / MCP runtime seam as ordinary players.

## What changed

### Worker auth
- adds `POST /api/player/auth/bot`
- issues standard bearer session tokens through the existing auth session path
- keeps gating tied to `TEST_BOT_AUTH_SECRET`

### CLI path
- `serve --bot-mode` can now request a server-issued token when no `--key` is provided
- existing private-key flow remains intact when `--key` is supplied

## Validation evidence

- CLI build passed
- a secret-gated token was issued successfully in local verification
- token-authenticated `GameClient` calls succeeded
- `serve --bot-mode` started successfully without a private key using the issued token

## Important non-goals

- does **not** define the final bot-auth product
- does **not** solve generalized harness orchestration
- does **not** replace wallet-based auth flows

## Review focus

1. Is the test-only bot auth path narrow and explicit enough?
2. Is the shared-secret gate acceptable for this review slice?
3. Does the CLI/server split preserve the platform boundary correctly?
