### PR TITLE
refactor(workers): extract platform identity boundary

### DIFF
--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -169,6 +169,12 @@ export interface LobbyPlayer {
   elo: number;
 }
 
+/**
+ * Player IDs exposed to game plugins are opaque platform-issued identifiers.
+ * Game code must not depend on wallet addresses, ERC-8004 token IDs, or chain metadata.
+ */
+export type PlatformPlayerId = string;
+
 /** A team in a lobby. */
 export interface LobbyTeam {
   id: string;

--- a/packages/workers-server/src/auth.ts
+++ b/packages/workers-server/src/auth.ts
@@ -1,8 +1,7 @@
-import { verifyMessage, createPublicClient, http, keccak256, toBytes } from 'viem';
-import { optimismSepolia } from 'viem/chains';
+import { verifyMessage } from 'viem';
 import type { Env } from './env.js';
-import { resolvePlayer, PlayerHandleTakenError } from './db/player.js';
-import { createRelay } from './chain/index.js';
+import { PlayerHandleTakenError } from './db/player.js';
+import { resolveAuthenticatedPlatformPlayer } from './platform/identity.js';
 
 const CHALLENGE_TTL_MS = 5 * 60 * 1000;    // 5 minutes
 const SESSION_TTL_MS   = 24 * 60 * 60 * 1000; // 24 hours
@@ -89,74 +88,30 @@ export async function handleAuthVerify(request: Request, env: Env): Promise<Resp
     );
   }
 
-  // Optional: ERC-8004 on-chain name ownership check
-  if (env.RPC_URL && env.REGISTRY_ADDRESS && env.ERC8004_ADDRESS) {
-    try {
-      const client = createPublicClient({
-        chain: optimismSepolia,
-        transport: http(env.RPC_URL),
-      });
-
-      const registryAbi = [{
-        name: 'nameToAgent',
-        type: 'function',
-        stateMutability: 'view',
-        inputs: [{ name: 'nameKey', type: 'bytes32' }],
-        outputs: [{ name: '', type: 'uint256' }],
-      }] as const;
-      const nameKey = keccak256(toBytes(name.toLowerCase()));
-      const agentId = await client.readContract({
-        address: env.REGISTRY_ADDRESS as `0x${string}`,
-        abi: registryAbi,
-        functionName: 'nameToAgent',
-        args: [nameKey],
-      } as any);
-
-      if (agentId === 0n) {
-        return Response.json({ error: `Name "${name}" is not registered on-chain` }, { status: 401 });
-      }
-
-      const erc8004Abi = [{
-        name: 'ownerOf',
-        type: 'function',
-        stateMutability: 'view',
-        inputs: [{ name: 'tokenId', type: 'uint256' }],
-        outputs: [{ name: '', type: 'address' }],
-      }] as const;
-      const owner = await client.readContract({
-        address: env.ERC8004_ADDRESS as `0x${string}`,
-        abi: erc8004Abi,
-        functionName: 'ownerOf',
-        args: [agentId],
-      } as any) as `0x${string}`;
-
-      if (owner.toLowerCase() !== address.toLowerCase()) {
-        return Response.json(
-          { error: `Address ${address} does not own name "${name}"` },
-          { status: 401 },
-        );
-      }
-
-      console.log(`[auth] On-chain verified: "${name}" owned by ${address}`);
-    } catch (err: any) {
-      console.error('[auth] On-chain verification failed:', err.message);
-      return Response.json({ error: 'On-chain verification failed: ' + err.message }, { status: 500 });
-    }
-  }
-
-  // Resolve player via read-through cache (chain → D1)
-  const trimmed = name.trim();
-  const relay = createRelay(env);
-
   let playerId: string;
   let reconnected: boolean;
+  let normalizedName: string;
   try {
-    const { player, created } = await resolvePlayer(address, relay, env.DB, { handle: trimmed });
-    playerId = player.id;
-    reconnected = !created;
-  } catch (err) {
+    const resolved = await resolveAuthenticatedPlatformPlayer(address, name, env);
+    playerId = resolved.playerId;
+    reconnected = resolved.reconnected;
+    normalizedName = resolved.name;
+    if (resolved.chainAgentId !== null) {
+      console.log(`[auth] On-chain verified: "${normalizedName}" owned by ${resolved.walletAddress} (agent ${resolved.chainAgentId})`);
+    }
+  } catch (err: any) {
     if (err instanceof PlayerHandleTakenError) {
       return Response.json({ error: err.message }, { status: 409 });
+    }
+    if (
+      String(err?.message ?? '').includes('is not registered on-chain') ||
+      String(err?.message ?? '').includes('does not own name')
+    ) {
+      return Response.json({ error: err.message }, { status: 401 });
+    }
+    if (String(err?.message ?? '').includes('on-chain')) {
+      console.error('[auth] On-chain verification failed:', err.message);
+      return Response.json({ error: 'On-chain verification failed: ' + err.message }, { status: 500 });
     }
     throw err;
   }
@@ -167,11 +122,11 @@ export async function handleAuthVerify(request: Request, env: Env): Promise<Resp
 
   await env.DB.prepare(
     'INSERT OR REPLACE INTO auth_sessions (token, player_id, name, expires_at) VALUES (?, ?, ?, ?)'
-  ).bind(token, playerId, trimmed, expiresAt).run();
+  ).bind(token, playerId, normalizedName, expiresAt).run();
 
-  console.log(`[auth] Verified "${trimmed}" wallet=${address.toLowerCase()} playerId=${playerId} reconnected=${reconnected}`);
+  console.log(`[auth] Verified "${normalizedName}" wallet=${address.toLowerCase()} playerId=${playerId} reconnected=${reconnected}`);
 
-  return Response.json({ token, agentId: playerId, name: trimmed, expiresAt, reconnected });
+  return Response.json({ token, agentId: playerId, name: normalizedName, expiresAt, reconnected });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/workers-server/src/platform/identity.ts
+++ b/packages/workers-server/src/platform/identity.ts
@@ -1,0 +1,103 @@
+import { createPublicClient, http, keccak256, toBytes } from 'viem';
+import { optimismSepolia } from 'viem/chains';
+
+import type { Env } from '../env.js';
+import { createRelay } from '../chain/index.js';
+import { resolvePlayer, PlayerHandleTakenError } from '../db/player.js';
+
+export interface PlatformIdentityVerification {
+  chainAgentId: number | null;
+}
+
+export interface AuthenticatedPlatformPlayer {
+  playerId: string;
+  name: string;
+  walletAddress: string;
+  chainAgentId: number | null;
+  reconnected: boolean;
+}
+
+export async function verifyOptionalPlatformIdentityOwnership(
+  address: string,
+  name: string,
+  env: Env,
+): Promise<PlatformIdentityVerification> {
+  if (!(env.RPC_URL && env.REGISTRY_ADDRESS && env.ERC8004_ADDRESS)) {
+    return { chainAgentId: null };
+  }
+
+  const client = createPublicClient({
+    chain: optimismSepolia,
+    transport: http(env.RPC_URL),
+  });
+
+  const registryAbi = [{
+    name: 'nameToAgent',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'nameKey', type: 'bytes32' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  }] as const;
+
+  const nameKey = keccak256(toBytes(name.toLowerCase()));
+  const agentId = await client.readContract({
+    address: env.REGISTRY_ADDRESS as `0x${string}`,
+    abi: registryAbi,
+    functionName: 'nameToAgent',
+    args: [nameKey],
+  } as const);
+
+  if (agentId === 0n) {
+    throw new Error(`Name "${name}" is not registered on-chain`);
+  }
+
+  const erc8004Abi = [{
+    name: 'ownerOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'tokenId', type: 'uint256' }],
+    outputs: [{ name: '', type: 'address' }],
+  }] as const;
+
+  const owner = await client.readContract({
+    address: env.ERC8004_ADDRESS as `0x${string}`,
+    abi: erc8004Abi,
+    functionName: 'ownerOf',
+    args: [agentId],
+  } as const) as `0x${string}`;
+
+  if (owner.toLowerCase() !== address.toLowerCase()) {
+    throw new Error(`Address ${address} does not own name "${name}"`);
+  }
+
+  return { chainAgentId: Number(agentId) };
+}
+
+export async function resolveAuthenticatedPlatformPlayer(
+  address: string,
+  name: string,
+  env: Env,
+): Promise<AuthenticatedPlatformPlayer> {
+  const trimmed = name.trim();
+  const walletAddress = address.toLowerCase();
+  const verification = await verifyOptionalPlatformIdentityOwnership(walletAddress, trimmed, env);
+  const relay = createRelay(env);
+
+  try {
+    const { player, created } = await resolvePlayer(walletAddress, relay, env.DB, {
+      handle: trimmed,
+      chainAgentId: verification.chainAgentId ?? undefined,
+    });
+
+    return {
+      playerId: player.id,
+      name: trimmed,
+      walletAddress,
+      chainAgentId: player.chainAgentId,
+      reconnected: !created,
+    };
+  } catch (err) {
+    if (err instanceof PlayerHandleTakenError) throw err;
+    throw err;
+  }
+}


### PR DESCRIPTION
# PR Notes — `djimo/platform-erc8004-boundary-r1`

## Branch

- Repo: `coordination-games`
- Branch: `djimo/platform-erc8004-boundary-r1`
- PR URL: `https://github.com/coordination-games/coordination-games/pull/new/djimo/platform-erc8004-boundary-r1`

## Suggested PR title

`Extract platform identity verification from auth`

## Suggested PR summary

This branch makes the ERC-8004 / on-chain identity seam more explicit in the workers platform layer. Optional on-chain name ownership verification and player resolution now live behind a dedicated helper instead of being inlined in `auth.ts`, while the engine gets a clearer contract that player IDs are opaque platform-issued identifiers.

The goal is to tighten the platform boundary without dragging game code into ERC-8004 semantics or broad naming churn.

## What changed

### Workers platform seam
- adds `packages/workers-server/src/platform/identity.ts`
- moves optional ERC-8004 / on-chain verification into that helper
- keeps `auth.ts` as the HTTP/error translation layer

### Engine contract note
- documents `PlatformPlayerId = string` in engine types as an opacity/boundary hint

## Validation evidence

- engine build passed
- helper extraction was reviewed as the right minimal first boundary cut

## Important non-goals

- does **not** rename all player IDs across the repo
- does **not** clean up local arena identity leaks
- does **not** change game/plugin contracts beyond the opacity note

## Review focus

1. Is the workers-side helper the right seam for optional platform identity verification?
2. Is the `PlatformPlayerId` documentation useful without overclaiming type safety?
3. Is the auth error classification acceptable and explicit enough?
