### PR TITLE
feat(cli): add Comedy sweep lane

### DIFF
--- a/scripts/comedy-sweep.config.json
+++ b/scripts/comedy-sweep.config.json
@@ -1,0 +1,26 @@
+{
+  "parallel": 1,
+  "cases": [
+    {
+      "name": "baseline-haiku",
+      "model": "haiku",
+      "botCount": 4,
+      "repeats": 1,
+      "promptAppend": "Play a balanced Comedy of the Commons game. Trade when it improves your medium-term position, but avoid obvious self-sabotage."
+    },
+    {
+      "name": "commons-steward",
+      "model": "haiku",
+      "botCount": 4,
+      "repeats": 1,
+      "promptAppend": "Prioritize long-term commons stewardship, reciprocal trade, and preserving productive ecosystems even if it lowers short-term extraction gains."
+    },
+    {
+      "name": "hard-bargainer",
+      "model": "haiku",
+      "botCount": 4,
+      "repeats": 1,
+      "promptAppend": "Prioritize leverage, opportunistic trades, and territorial growth. Cooperate only when it clearly improves your expected payout."
+    }
+  ]
+}

--- a/scripts/run-comedy-sweep.ts
+++ b/scripts/run-comedy-sweep.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+interface SweepCase {
+  name: string;
+  model?: string;
+  botCount?: number;
+  repeats?: number;
+  promptAppend?: string;
+}
+
+interface SweepConfig {
+  parallel?: number;
+  cases: SweepCase[];
+}
+
+interface SweepJob {
+  caseName: string;
+  iteration: number;
+  model: string;
+  botCount: number;
+  promptAppend: string;
+}
+
+function parseArgs(argv: string[]) {
+  const parsed: Record<string, string | boolean> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      parsed[key] = true;
+      continue;
+    }
+    parsed[key] = next;
+    i += 1;
+  }
+  return parsed;
+}
+
+async function loadSweepConfig(configPath: string): Promise<SweepConfig> {
+  const raw = await readFile(configPath, 'utf-8');
+  return JSON.parse(raw) as SweepConfig;
+}
+
+async function runJob(job: SweepJob, serverUrl: string, outDir: string, dryRun: boolean) {
+  const runLabel = `${job.caseName}-run-${job.iteration}`;
+  const stdoutPath = path.join(outDir, `${runLabel}.stdout.log`);
+  const stderrPath = path.join(outDir, `${runLabel}.stderr.log`);
+  const startedAt = Date.now();
+
+  if (dryRun) {
+    return {
+      runLabel,
+      caseName: job.caseName,
+      iteration: job.iteration,
+      model: job.model,
+      botCount: job.botCount,
+      promptAppend: job.promptAppend,
+      stdoutPath,
+      stderrPath,
+      dryRun: true,
+    };
+  }
+
+  return await new Promise<Record<string, unknown>>((resolve, reject) => {
+    const child = spawn('npx', ['tsx', 'scripts/run-game.ts'], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        GAME_SERVER: serverUrl,
+        GAME_TYPE: 'comedy-of-the-commons',
+        BOT_COUNT: String(job.botCount),
+        LOBBY_SIZE: String(job.botCount),
+        MODEL: job.model,
+        RUN_LABEL: runLabel,
+        PROMPT_APPEND: job.promptAppend,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      writeFileSync(stdoutPath, stdout, 'utf-8');
+      writeFileSync(stderrPath, stderr, 'utf-8');
+      resolve({
+        runLabel,
+        caseName: job.caseName,
+        iteration: job.iteration,
+        model: job.model,
+        botCount: job.botCount,
+        exitCode: code,
+        durationMs: Date.now() - startedAt,
+        stdoutPath,
+        stderrPath,
+      });
+    });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const configPath = String(args.config || 'scripts/comedy-sweep.config.json');
+  const caseFilter = typeof args.case === 'string' ? args.case : undefined;
+  const serverUrl = String(args['server-url'] || process.env.GAME_SERVER || 'http://localhost:8787');
+  const dryRun = Boolean(args['dry-run']);
+  const config = await loadSweepConfig(configPath);
+  const parallel = Number(args.parallel || config.parallel || 1);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outDir = path.join(process.cwd(), 'artifacts', 'comedy-sweeps', timestamp);
+  mkdirSync(outDir, { recursive: true });
+
+  const selectedCases = config.cases.filter((entry) => !caseFilter || entry.name === caseFilter);
+  const jobs: SweepJob[] = [];
+  for (const entry of selectedCases) {
+    const repeats = Math.max(1, entry.repeats ?? 1);
+    for (let iteration = 1; iteration <= repeats; iteration++) {
+      jobs.push({
+        caseName: entry.name,
+        iteration,
+        model: entry.model ?? 'haiku',
+        botCount: Math.max(4, entry.botCount ?? 4),
+        promptAppend: entry.promptAppend ?? '',
+      });
+    }
+  }
+
+  const resultsPath = path.join(outDir, 'results.jsonl');
+  const pending = [...jobs];
+  const running = new Set<Promise<void>>();
+
+  async function launch(job: SweepJob) {
+    const result = await runJob(job, serverUrl, outDir, dryRun);
+    writeFileSync(resultsPath, `${JSON.stringify(result)}\n`, { encoding: 'utf-8', flag: 'a' });
+  }
+
+  while (pending.length > 0 || running.size > 0) {
+    while (pending.length > 0 && running.size < parallel) {
+      const job = pending.shift()!;
+      const promise = launch(job).finally(() => running.delete(promise));
+      running.add(promise);
+    }
+    if (running.size > 0) {
+      await Promise.race(running);
+    }
+  }
+
+  process.stdout.write(`Comedy sweep complete. Artifacts: ${outDir}\n`);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/run-game.ts
+++ b/scripts/run-game.ts
@@ -49,6 +49,11 @@ const BOT_COUNT = parseInt(
   process.env.BOT_COUNT ?? (GAME_TYPE === 'oathbreaker' ? '4' : String(TEAM_SIZE * 2))
 );
 const MODEL = process.env.MODEL ?? 'haiku';
+const LOBBY_SIZE = parseInt(
+  process.env.LOBBY_SIZE ?? (GAME_TYPE === 'oathbreaker' || GAME_TYPE === 'comedy-of-the-commons' ? String(BOT_COUNT) : String(TEAM_SIZE))
+);
+const RUN_LABEL = process.env.RUN_LABEL ?? `${GAME_TYPE}-${Date.now()}`;
+const PROMPT_APPEND = (process.env.PROMPT_APPEND ?? '').trim();
 
 // ---------------------------------------------------------------------------
 // REST helper
@@ -136,9 +141,17 @@ Play the game to completion using the "game" MCP server tools.
 5. Keep calling wait_for_update and submitting moves until gameOver: true
 6. Do NOT stop early or summarize — keep playing every round
 
-IMPORTANT: You have a chat tool — USE IT EVERY TURN. Tell your teammate what you see, where enemies are, and what you plan to do. Coordinate! Solo play loses.`;
+Run label: ${RUN_LABEL}
 
-  const resumePrompt = `The game is still in progress. Continue playing — call wait_for_update, chat with your teammate about what you see, then submit_move. Repeat until gameOver: true. Do NOT summarize or stop early. USE THE CHAT TOOL every turn to coordinate.`;
+IMPORTANT: You have a chat tool — USE IT EVERY TURN. Tell your teammate what you see, where enemies are, and what you plan to do. Coordinate! Solo play loses.${PROMPT_APPEND ? `
+
+Additional persona guidance:
+${PROMPT_APPEND}` : ''}`;
+
+  const resumePrompt = `The game is still in progress. Continue playing — call wait_for_update, chat with your teammate about what you see, then submit_move. Repeat until gameOver: true. Do NOT summarize or stop early. USE THE CHAT TOOL every turn to coordinate.${PROMPT_APPEND ? `
+
+Additional persona guidance:
+${PROMPT_APPEND}` : ''}`;
 
   /** Run one claude --print invocation; resolves with stdout text. */
   function runOnce(prompt: string, isResume: boolean): Promise<string> {
@@ -299,7 +312,9 @@ async function completeLobbyPhases(
 // ---------------------------------------------------------------------------
 
 async function main() {
-  console.log(`\nrun-game.ts — ${BOT_COUNT} bots playing ${GAME_TYPE} on ${SERVER}\n`);
+  console.log(`\nrun-game.ts — ${BOT_COUNT} bots playing ${GAME_TYPE} on ${SERVER}`);
+  console.log(`run-label: ${RUN_LABEL}`);
+  console.log(`model: ${MODEL}\n`);
 
   // 1. Create wallets and authenticate
   console.log('Creating wallets and authenticating...');
@@ -320,9 +335,7 @@ async function main() {
 
   // 2. Create the lobby
   console.log(`\nCreating ${GAME_TYPE} lobby...`);
-  const lobbyBody = GAME_TYPE === 'oathbreaker'
-    ? { gameType: GAME_TYPE, teamSize: BOT_COUNT }
-    : { gameType: GAME_TYPE, teamSize: TEAM_SIZE };
+  const lobbyBody = { gameType: GAME_TYPE, teamSize: LOBBY_SIZE };
 
   const lobby = await api('/api/lobbies/create', { method: 'POST', body: lobbyBody, token: bots[0].token });
   const lobbyId = lobby.lobbyId;

--- a/wiki/development/comedy-sweep.md
+++ b/wiki/development/comedy-sweep.md
@@ -1,0 +1,56 @@
+# Comedy Sweep Lane
+
+This is the first reusable **Comedy of the Commons** sweep lane.
+
+It is intentionally thin:
+
+- reuse the real platform-aligned runner in `scripts/run-game.ts`
+- lock the game type to `comedy-of-the-commons`
+- vary a small matrix of persona/model presets
+- emit structured run artifacts for later comparison
+
+## Run a sweep
+
+```bash
+npx tsx scripts/run-comedy-sweep.ts
+```
+
+Run a specific case only:
+
+```bash
+npx tsx scripts/run-comedy-sweep.ts --case commons-steward
+```
+
+Preview the planned sweep without starting games:
+
+```bash
+npx tsx scripts/run-comedy-sweep.ts --dry-run
+```
+
+Artifacts are written under:
+
+```bash
+artifacts/comedy-sweeps/<timestamp>/
+```
+
+Each run appends one JSON line to `results.jsonl` and writes matching stdout/stderr logs.
+
+## Why this exists
+
+This slice is **Comedy-first** and deliberately avoids building a generic harness platform too early.
+
+It gives us:
+
+- repeatable Comedy runs
+- simple persona/model comparisons
+- machine-readable artifacts
+- one bridge from local gameplay proof to later harness sweeps
+
+## What it does not do yet
+
+- no generic multi-game sweep framework
+- no final benchmark/evaluation scoring
+- no dependence on the OATHBREAKER local emulator path
+- no requirement for the 85b bot-token path
+
+It is a thin wrapper around the existing runner, not a new harness subsystem.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -19,6 +19,7 @@ Non-obvious knowledge, design decisions, specs, and gotchas. For the game author
 - [npm Workspace Bugs](development/npm-workspace-bugs.md) — devDependencies not installed, @types ghost installs
 - [Adding a Game](development/adding-a-game.md) — checklist, what you get for free, lobby config patterns
 - [Bot System](development/bot-system.md) — Haiku bots via Agent SDK, auth bypass, generic harness
+- [Comedy Sweep](development/comedy-sweep.md) — thin Comedy-first persona/model sweep lane
 - [Hex Grid Rendering](development/hex-grid-rendering.md) — flat-top coords, Wesnoth assets, forest layering, map scaling
 
 ## Specs (Designed, Not Yet Built)


### PR DESCRIPTION
## Summary
- add a Comedy-first sweep wrapper around the existing real-platform runner
- add a small Comedy sweep config with initial persona/model cases
- document the sweep lane and artifact output path

## Scope
This is intentionally a thin Comedy-specific sweep lane, not a generalized multi-game harness framework.

## Verification
- dry-run planning succeeded and wrote artifact metadata
- real-platform smoke path authenticated bots and created/filled a Comedy lobby
