### PR TITLE
feat(cli): add opt-in rationale plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/plugins/*"
   ],
   "scripts": {
-    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/plugins/basic-chat -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
+    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/plugins/basic-chat -w packages/plugins/rationale -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
     "test": "npm run test --workspaces --if-present",
     "dev": "npm run dev --workspace=packages/workers-server",
     "dev:web": "npm run dev --workspace=packages/web",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,9 @@
     "access": "public",
     "provenance": true
   },
-  "dependencies": {},
+  "dependencies": {
+    "@coordination-games/plugin-rationale": "*"
+  },
   "devDependencies": {
     "@types/node": "^22.19.15",
     "typescript": "^5.4.0",

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import crypto from "node:crypto";
+import type { ToolPlugin } from "@coordination-games/engine";
 
 export function registerServeCommand(program: Command) {
   program
@@ -10,10 +11,16 @@ export function registerServeCommand(program: Command) {
     .option("--bot-mode", undefined, false)  // hidden: internal testing
     .option("--key <key>", undefined)         // hidden: bot private key
     .option("--name <name>", undefined)       // hidden: bot display name
+    .option("--with-rationale", undefined, false) // hidden: opt-in rationale plugin
     .option("--server-url <url>", "Game server URL (default: from config)")
     .action(async (opts) => {
       // Dynamic import to avoid loading MCP deps when not needed
       const { startMcpServer } = await import("../mcp-server.js");
+      const plugins: ToolPlugin[] = [];
+      if (opts.withRationale) {
+        const { RationalePlugin } = await import("@coordination-games/plugin-rationale");
+        plugins.push(RationalePlugin);
+      }
 
       const httpPort = typeof opts.http === "string" ? parseInt(opts.http, 10) : undefined;
       const mode: "stdio" | "http" = opts.http ? "http" : "stdio";
@@ -31,6 +38,7 @@ export function registerServeCommand(program: Command) {
           name,
           botMode: true,
           httpPort,
+          plugins,
         });
       } else {
         // Normal mode: use local wallet from ~/.coordination/keys/
@@ -64,6 +72,7 @@ export function registerServeCommand(program: Command) {
           name,
           botMode: false,
           httpPort,
+          plugins,
         });
       }
     });

--- a/packages/cli/src/game-client.ts
+++ b/packages/cli/src/game-client.ts
@@ -231,6 +231,6 @@ export class GameClient {
     const output = processState(raw);
     // Drop the raw relay log + the pipelineOutput map (they duplicate `messages`)
     const { relayMessages: _r, ...rest } = raw;
-    return { ...rest, messages: output.messages };
+    return { ...rest, messages: output.messages, rationales: output.rationales };
   }
 }

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -17,6 +17,7 @@ import { GameClient } from "./game-client.js";
 import { registerGameTools } from "./mcp-tools.js";
 import { loadConfig } from "./config.js";
 import { BasicChatPlugin } from "@coordination-games/plugin-chat";
+import type { ToolPlugin } from "@coordination-games/engine";
 
 export interface ServeOptions {
   serverUrl: string;
@@ -24,6 +25,7 @@ export interface ServeOptions {
   name?: string;
   botMode?: boolean;
   httpPort?: number;
+  plugins?: ToolPlugin[];
 }
 
 function createMcpServerWithClient(options?: ServeOptions): { server: McpServer; client: GameClient } {
@@ -36,7 +38,7 @@ function createMcpServerWithClient(options?: ServeOptions): { server: McpServer;
     name: "coordination-games",
     version: "0.1.0",
   });
-  registerGameTools(server, client, { botMode: options?.botMode, plugins: [BasicChatPlugin] });
+  registerGameTools(server, client, { botMode: options?.botMode, plugins: [BasicChatPlugin, ...(options?.plugins ?? [])] });
   return { server, client };
 }
 

--- a/packages/cli/src/pipeline.ts
+++ b/packages/cli/src/pipeline.ts
@@ -64,6 +64,7 @@ export function processState(serverResponse: {
 }): {
   gameState: any;
   messages: any[];
+  rationales: any[];
   pipelineOutput: Map<string, any>;
   raw: any;
 } {
@@ -73,6 +74,7 @@ export function processState(serverResponse: {
   return {
     gameState: serverResponse.gameState ?? serverResponse,
     messages: pipelineOutput.get('messaging') ?? [],
+    rationales: pipelineOutput.get('rationale') ?? [],
     pipelineOutput,
     raw: serverResponse,
   };

--- a/packages/plugins/rationale/package.json
+++ b/packages/plugins/rationale/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@coordination-games/plugin-rationale",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc --skipLibCheck",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@coordination-games/engine": "*"
+  },
+  "devDependencies": {
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/plugins/rationale/src/__tests__/rationale.test.ts
+++ b/packages/plugins/rationale/src/__tests__/rationale.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { RationalePlugin, extractRationales, formatRationaleMessage } from '../index.js';
+
+describe('RationalePlugin', () => {
+  it('formats outgoing rationale relay data', () => {
+    const relay = formatRationaleMessage('We should coordinate left flank.', 'team', 'planning');
+    expect(relay.type).toBe('rationale');
+    expect(relay.pluginId).toBe('rationale');
+    expect(relay.scope).toBe('team');
+    expect(relay.data).toEqual({ body: 'We should coordinate left flank.', stage: 'planning' });
+  });
+
+  it('extracts rationale entries from raw relay messages', () => {
+    const entries = extractRationales([
+      {
+        type: 'rationale',
+        data: { body: 'Commit to cooperation this round.', stage: 'negotiation' },
+        scope: 'all',
+        pluginId: 'rationale',
+        sender: 'agent-1',
+        turn: 3,
+        timestamp: 123,
+        index: 0,
+      },
+    ]);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      from: 'agent-1',
+      body: 'Commit to cooperation this round.',
+      turn: 3,
+      scope: 'all',
+      stage: 'negotiation',
+    });
+  });
+
+  it('publishes rationale relay payloads through the plugin tool', () => {
+    const result = RationalePlugin.handleCall?.(
+      'share_rationale',
+      { message: 'Trade ore for tempo.', scope: 'agent-2', stage: 'action' },
+      { id: 'agent-1', handle: 'alice' },
+    ) as any;
+
+    expect(result.relay).toEqual({
+      type: 'rationale',
+      data: { body: 'Trade ore for tempo.', stage: 'action' },
+      scope: 'agent-2',
+      pluginId: 'rationale',
+    });
+  });
+});

--- a/packages/plugins/rationale/src/index.ts
+++ b/packages/plugins/rationale/src/index.ts
@@ -1,0 +1,91 @@
+import type { ToolPlugin, AgentInfo } from '@coordination-games/engine';
+
+export interface RelayMessage {
+  type: string;
+  data: unknown;
+  scope: 'team' | 'all' | string;
+  pluginId: string;
+  sender: string;
+  turn: number;
+  timestamp: number;
+  index: number;
+}
+
+export interface RationaleEntry {
+  from: string;
+  body: string;
+  turn: number;
+  scope: 'team' | 'all' | string;
+  stage?: string;
+  tags: Record<string, any>;
+}
+
+export function formatRationaleMessage(message: string, scope = 'all', stage?: string) {
+  return {
+    type: 'rationale',
+    data: {
+      body: message,
+      ...(stage ? { stage } : {}),
+    },
+    scope,
+    pluginId: 'rationale',
+  };
+}
+
+export function extractRationales(relayMessages: RelayMessage[]): RationaleEntry[] {
+  return relayMessages
+    .filter((msg) => msg.type === 'rationale')
+    .map((msg) => {
+      const data = msg.data as { body?: string; stage?: string; tags?: Record<string, any> };
+      return {
+        from: msg.sender,
+        body: data.body ?? '',
+        turn: msg.turn,
+        scope: msg.scope,
+        stage: data.stage,
+        tags: {
+          ...data.tags,
+          source: msg.pluginId,
+          sender: msg.sender,
+          timestamp: msg.timestamp,
+        },
+      } satisfies RationaleEntry;
+    });
+}
+
+export const RationalePlugin: ToolPlugin = {
+  id: 'rationale',
+  version: '0.1.0',
+  modes: [{ name: 'rationale', consumes: [], provides: ['rationale'] }],
+  purity: 'pure',
+  tools: [
+    {
+      name: 'share_rationale',
+      description:
+        'Publish an explicit authored rationale entry to the relay. Use this for observable strategy notes or justification, not hidden chain-of-thought.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          message: { type: 'string', description: 'The rationale or strategy note to publish.' },
+          scope: { type: 'string', description: 'Who receives it: "team", "all", or a specific agentId for a DM-like rationale.' },
+          stage: { type: 'string', description: 'Optional phase label such as planning, negotiation, action, or reflection.' },
+        },
+        required: ['message'],
+      },
+      mcpExpose: true,
+    },
+  ],
+  handleData(_mode: string, inputs: Map<string, any>): Map<string, any> {
+    const relayMessages: RelayMessage[] = inputs.get('relay-messages') ?? [];
+    return new Map([['rationale', extractRationales(relayMessages)]]);
+  },
+  handleCall(tool: string, args: unknown, _caller: AgentInfo): unknown {
+    if (tool === 'share_rationale') {
+      const { message, scope, stage } = args as { message: string; scope?: string; stage?: string };
+      return {
+        relay: formatRationaleMessage(message, scope || 'all', stage),
+      };
+    }
+    return { error: `Unknown tool: ${tool}` };
+  },
+};

--- a/packages/plugins/rationale/tsconfig.json
+++ b/packages/plugins/rationale/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "composite": true
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated rationale plugin package
- make rationale opt-in via hidden CLI flag instead of default-on
- expose rationale pipeline output additively without changing default runtime behavior

## Scope
This is the minimal latest-main-compatible rationale recut. Worker/web/runtime default behavior remains unchanged unless the CLI explicitly enables the plugin.

## Verification
- rationale plugin build passed
- rationale plugin tests passed
- CLI build passed
- serve path worked with explicit rationale opt-in enabled
