### PR TITLE
fix(engine): remove Buffer dependency from worker settlement path

### DIFF
--- a/packages/engine/src/merkle.bufferless.test.ts
+++ b/packages/engine/src/merkle.bufferless.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { buildActionMerkleTree, encodeLeaf, verifyProof, generateProof } from './merkle.js';
+
+describe('merkle hashing without Buffer global', () => {
+  it('builds and verifies leaves when Buffer is unavailable', () => {
+    const originalBuffer = (globalThis as any).Buffer;
+    try {
+      (globalThis as any).Buffer = undefined;
+
+      const leaves = [
+        { actionIndex: 0, playerId: 'player-a', actionData: JSON.stringify({ type: 'move' }), stateHash: 's1' },
+        { actionIndex: 1, playerId: null, actionData: JSON.stringify({ type: 'game_start' }), stateHash: 's2' },
+      ];
+
+      const tree = buildActionMerkleTree(leaves);
+      expect(tree.root).toBeTruthy();
+      expect(tree.leaves).toHaveLength(2);
+
+      const proof = generateProof(tree, 0);
+      expect(verifyProof(tree.root, proof)).toBe(true);
+      expect(encodeLeaf(leaves[0])).toBe(tree.leaves[0]);
+    } finally {
+      (globalThis as any).Buffer = originalBuffer;
+    }
+  });
+});

--- a/packages/engine/src/merkle.ts
+++ b/packages/engine/src/merkle.ts
@@ -16,13 +16,13 @@ import crypto from 'node:crypto';
 // ---------------------------------------------------------------------------
 
 /** Hash a buffer with SHA-256. In production, replace with keccak256. */
-function hashBuffer(data: Buffer): string {
+function hashBuffer(data: Uint8Array): string {
   return crypto.createHash('sha256').update(data).digest('hex');
 }
 
 /** Hash a string with SHA-256. */
 function hashString(data: string): string {
-  return hashBuffer(Buffer.from(data, 'utf-8'));
+  return hashBuffer(new TextEncoder().encode(data));
 }
 
 /** Hash two child hashes together (sorted for order independence). */


### PR DESCRIPTION
## Summary
- remove the Node Buffer dependency from the worker-side settlement / merkle path
- keep the latest-main Comedy worker replay/demo flow from failing when settlement executes inside the Cloudflare worker runtime
- preserve existing settlement semantics while fixing the runtime-specific incompatibility

## Why
The clean-start Comedy smoke exposed a real worker runtime defect: settlement tried to use `Buffer` inside the worker path. This branch fixes that concrete latest-main blocker.

## Scope
Focused runtime fix only; no new demo/product surface is added here.