### PR TITLE
feat(cli): add Comedy full-completion smoke mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "packages/plugins/*"
   ],
   "scripts": {
-    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/plugins/basic-chat -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
+    "build": "npm run build -w packages/engine && npm run build -w packages/games/capture-the-lobster -w packages/games/oathbreaker -w packages/games/comedy-of-the-commons -w packages/plugins/basic-chat -w packages/plugins/elo && npm run build -w packages/web -w packages/cli",
     "test": "npm run test --workspaces --if-present",
     "dev": "npm run dev --workspace=packages/workers-server",
     "dev:web": "npm run dev --workspace=packages/web",

--- a/packages/games/comedy-of-the-commons/README.md
+++ b/packages/games/comedy-of-the-commons/README.md
@@ -1,0 +1,46 @@
+# Comedy of the Commons
+
+Initial upstream package scaffold for bringing **Comedy of the Commons** into the `coordination-games` engine as a normal `CoordinationGame` plugin.
+
+This package is intentionally being built in phases.
+
+## Purpose of this first slice
+
+This branch starts the upstream port without pretending the full local prototype is already ported.
+
+What this first step does:
+
+- reserves the upstream package path
+- defines the initial v0 type surface
+- records the source-material mapping back to the richer local prototype
+
+What this first step does **not** claim yet:
+
+- full gameplay loop parity
+- trust portability
+- commitment / attestation parity
+- Olympiad support
+
+## Local source material
+
+Primary source files currently live in the local arena prototype:
+
+- `arena/src/games/nexus/comedy-engine.ts`
+- `arena/src/games/nexus/types.ts`
+- `arena/src/games/nexus/world-map.ts`
+- `arena/src/games/nexus/trade.ts`
+
+The upstream port should stay smaller than the local prototype at first.
+
+## Intended v0 shape
+
+Comedy v0 should become the smallest playable upstream slice:
+
+- game package under `packages/games/comedy-of-the-commons`
+- simple config builder / lobby path
+- spectator plugin later
+- basic resource, commons, trading, and building loop
+
+## Rule
+
+Do not silently port every rich subsystem from the local arena. Add only what is required for a believable playable v0, then layer v1/v2 features in later slices.

--- a/packages/games/comedy-of-the-commons/package.json
+++ b/packages/games/comedy-of-the-commons/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@coordination-games/game-comedy-of-the-commons",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --skipLibCheck"
+  },
+  "dependencies": {
+    "@coordination-games/engine": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/games/comedy-of-the-commons/src/game.ts
+++ b/packages/games/comedy-of-the-commons/src/game.ts
@@ -1,0 +1,488 @@
+import type { ActionResult } from '@coordination-games/engine';
+import {
+  type ComedyAction,
+  type ComedyConfig,
+  type ComedyEcosystem,
+  type ComedyOutcome,
+  type ComedyPlayerState,
+  type ComedyRegion,
+  type ComedyState,
+  type ComedyTradeOffer,
+  type ExtractionLevel,
+  type ResourceInventory,
+  type ResourceType,
+} from './types.js';
+
+const RESOURCE_CAP = 14;
+const SETTLEMENT_COST: Partial<ResourceInventory> = {
+  grain: 1,
+  timber: 1,
+  ore: 1,
+  water: 1,
+};
+
+const EXTRACTION_PROFILES: Record<ExtractionLevel, { yield: number; pressure: number }> = {
+  low: { yield: 1, pressure: 1 },
+  medium: { yield: 2, pressure: 3 },
+  high: { yield: 3, pressure: 6 },
+};
+
+const STARTING_RESOURCES: ResourceInventory = {
+  grain: 2,
+  timber: 2,
+  ore: 1,
+  fish: 1,
+  water: 1,
+  energy: 1,
+};
+
+function cloneResources(resources: ResourceInventory): ResourceInventory {
+  return { ...resources };
+}
+
+function totalResources(resources: ResourceInventory): number {
+  return Object.values(resources).reduce((sum, value) => sum + value, 0);
+}
+
+function canAfford(resources: ResourceInventory, cost: Partial<ResourceInventory>): boolean {
+  return Object.entries(cost).every(([key, value]) => resources[key as ResourceType] >= (value ?? 0));
+}
+
+function deductCost(resources: ResourceInventory, cost: Partial<ResourceInventory>): void {
+  for (const [key, value] of Object.entries(cost)) {
+    resources[key as ResourceType] -= value ?? 0;
+  }
+}
+
+function addResource(resources: ResourceInventory, resource: ResourceType, amount: number): number {
+  const currentTotal = totalResources(resources);
+  if (currentTotal >= RESOURCE_CAP) return 0;
+  const accepted = Math.min(amount, RESOURCE_CAP - currentTotal);
+  resources[resource] += accepted;
+  return accepted;
+}
+
+function inventoryEquals(left: Partial<ResourceInventory>, right: Partial<ResourceInventory>): boolean {
+  const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+  for (const key of keys) {
+    if ((left[key as ResourceType] ?? 0) !== (right[key as ResourceType] ?? 0)) return false;
+  }
+  return true;
+}
+
+function getBaseRegions(): ComedyRegion[] {
+  return [
+    { id: 'mistbarrow', name: 'Mistbarrow', primaryResource: 'timber', secondaryResources: ['water'], ecosystemIds: ['old-growth-ring'] },
+    { id: 'riverwake', name: 'Riverwake', primaryResource: 'water', secondaryResources: ['fish', 'grain'], ecosystemIds: ['sunspine-aquifer'] },
+    { id: 'commons-heart', name: 'Commons Heart', primaryResource: 'grain', secondaryResources: ['timber', 'water'], ecosystemIds: ['old-growth-ring', 'sunspine-aquifer'] },
+    { id: 'sunspine-basin', name: 'Sunspine Basin', primaryResource: 'energy', secondaryResources: ['ore'], ecosystemIds: ['sunspine-aquifer'] },
+    { id: 'ironcrest', name: 'Ironcrest', primaryResource: 'ore', secondaryResources: ['energy'], ecosystemIds: [] },
+    { id: 'monsoon-reach', name: 'Monsoon Reach', primaryResource: 'fish', secondaryResources: ['water', 'grain'], ecosystemIds: ['silver-tide-fishery'] },
+  ];
+}
+
+function getBaseEcosystems(): ComedyEcosystem[] {
+  return [
+    {
+      id: 'old-growth-ring',
+      name: 'Old Growth Ring',
+      kind: 'forest',
+      resource: 'timber',
+      regionIds: ['mistbarrow', 'commons-heart'],
+      health: 16,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+    {
+      id: 'sunspine-aquifer',
+      name: 'Sunspine Aquifer',
+      kind: 'aquifer',
+      resource: 'water',
+      regionIds: ['riverwake', 'commons-heart', 'sunspine-basin'],
+      health: 15,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+    {
+      id: 'silver-tide-fishery',
+      name: 'Silver Tide Fishery',
+      kind: 'fishery',
+      resource: 'fish',
+      regionIds: ['monsoon-reach'],
+      health: 14,
+      maxHealth: 20,
+      collapseThreshold: 4,
+      flourishThreshold: 16,
+    },
+  ];
+}
+
+function createPlayers(playerIds: string[], regions: ComedyRegion[]): ComedyPlayerState[] {
+  return playerIds.map((id, index) => ({
+    id,
+    resources: cloneResources(STARTING_RESOURCES),
+    influence: 0,
+    vp: 1,
+    regionsControlled: [regions[index % regions.length].id],
+  }));
+}
+
+function makeSubmittedActions(playerIds: string[]): Record<string, ComedyAction | null> {
+  return Object.fromEntries(playerIds.map((id) => [id, null]));
+}
+
+function ecosystemStatus(ecosystem: ComedyEcosystem): 'flourishing' | 'stable' | 'strained' | 'collapsed' {
+  if (ecosystem.health <= ecosystem.collapseThreshold) return 'collapsed';
+  if (ecosystem.health >= ecosystem.flourishThreshold) return 'flourishing';
+  if (ecosystem.health <= Math.ceil(ecosystem.maxHealth / 2)) return 'strained';
+  return 'stable';
+}
+
+function getYieldMultiplier(ecosystem: ComedyEcosystem): number {
+  const status = ecosystemStatus(ecosystem);
+  if (status === 'flourishing') return 1.5;
+  if (status === 'collapsed') return 0.5;
+  if (status === 'strained') return 0.8;
+  return 1;
+}
+
+function applyProduction(state: ComedyState): ComedyState {
+  const ecosystems = state.ecosystems.map((ecosystem) => ({ ...ecosystem }));
+  const ecosystemById = new Map(ecosystems.map((ecosystem) => [ecosystem.id, ecosystem]));
+  const players = state.players.map((player) => ({ ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] }));
+  const regionsById = new Map(state.regions.map((region) => [region.id, region]));
+
+  for (const player of players) {
+    for (const regionId of player.regionsControlled) {
+      const region = regionsById.get(regionId);
+      if (!region) continue;
+      addResource(player.resources, region.primaryResource, 1);
+      for (const ecosystemId of region.ecosystemIds) {
+        const ecosystem = ecosystemById.get(ecosystemId);
+        if (ecosystem && ecosystemStatus(ecosystem) === 'flourishing') {
+          addResource(player.resources, ecosystem.resource, 1);
+          break;
+        }
+      }
+    }
+  }
+
+  return { ...state, players, ecosystems };
+}
+
+function startRound(state: ComedyState): ComedyState {
+  const round = state.round + 1;
+  const started = {
+    ...state,
+    round,
+    phase: 'playing' as const,
+    activeTrades: [],
+    submittedActions: makeSubmittedActions(state.players.map((player) => player.id)),
+  };
+  return applyProduction(started);
+}
+
+function allPlayersSubmitted(state: ComedyState): boolean {
+  return state.players.every((player) => state.submittedActions[player.id] !== null);
+}
+
+function resolveTrades(
+  players: ComedyPlayerState[],
+  submittedByPlayer: Array<{ playerId: string; action: ComedyAction }>,
+): ComedyTradeOffer[] {
+  const playerMap = new Map(players.map((player) => [player.id, player]));
+  const completed: ComedyTradeOffer[] = [];
+  const used = new Set<number>();
+
+  for (let i = 0; i < submittedByPlayer.length; i++) {
+    const current = submittedByPlayer[i];
+    if (current.action.type !== 'offer_trade' || used.has(i)) continue;
+    for (let j = i + 1; j < submittedByPlayer.length; j++) {
+      const other = submittedByPlayer[j];
+      if (other.action.type !== 'offer_trade' || used.has(j)) continue;
+      if (current.playerId === other.playerId) continue;
+      if (current.action.offer.to !== other.playerId) continue;
+      if (other.action.offer.to !== current.playerId) continue;
+      if (!inventoryEquals(current.action.offer.give, other.action.offer.receive)) continue;
+      if (!inventoryEquals(current.action.offer.receive, other.action.offer.give)) continue;
+
+      const actionSender = playerMap.get(current.playerId);
+      const otherSender = playerMap.get(other.playerId);
+      if (!actionSender || !otherSender) continue;
+      if (!canAfford(actionSender.resources, current.action.offer.give)) continue;
+      if (!canAfford(otherSender.resources, other.action.offer.give)) continue;
+
+      deductCost(actionSender.resources, current.action.offer.give);
+      deductCost(otherSender.resources, other.action.offer.give);
+      for (const [resource, amount] of Object.entries(current.action.offer.receive)) {
+        actionSender.resources[resource as ResourceType] += amount ?? 0;
+      }
+      for (const [resource, amount] of Object.entries(other.action.offer.receive)) {
+        otherSender.resources[resource as ResourceType] += amount ?? 0;
+      }
+      actionSender.influence += 1;
+      otherSender.influence += 1;
+      completed.push(current.action.offer, other.action.offer);
+      used.add(i);
+      used.add(j);
+      break;
+    }
+  }
+
+  return completed;
+}
+
+function resolveRound(state: ComedyState): ComedyState {
+  const players = state.players.map((player) => ({ ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] }));
+  const ecosystems = state.ecosystems.map((ecosystem) => ({ ...ecosystem }));
+  const ecosystemById = new Map(ecosystems.map((ecosystem) => [ecosystem.id, ecosystem]));
+  const submittedByPlayer = players.map((player) => ({
+    playerId: player.id,
+    action: state.submittedActions[player.id] ?? ({ type: 'pass' } as ComedyAction),
+  }));
+
+  const completedTrades = resolveTrades(players, submittedByPlayer);
+  const pressureByEcosystem = new Map<string, number>();
+
+  for (let index = 0; index < players.length; index++) {
+    const player = players[index];
+    const action = submittedByPlayer[index].action;
+    if (action.type === 'extract_commons') {
+      const ecosystem = ecosystemById.get(action.ecosystemId);
+      if (!ecosystem) continue;
+      const controlsRegion = ecosystem.regionIds.some((regionId) => player.regionsControlled.includes(regionId));
+      if (!controlsRegion) continue;
+      const profile = EXTRACTION_PROFILES[action.level];
+      const accepted = addResource(player.resources, ecosystem.resource, Math.max(1, Math.round(profile.yield * getYieldMultiplier(ecosystem))));
+      if (accepted > 0) {
+        pressureByEcosystem.set(ecosystem.id, (pressureByEcosystem.get(ecosystem.id) ?? 0) + profile.pressure);
+      }
+      continue;
+    }
+
+    if (action.type === 'build_settlement') {
+      if (!action.regionId) continue;
+      if (!canAfford(player.resources, SETTLEMENT_COST)) continue;
+      const regionTaken = players.some((other) => other.regionsControlled.includes(action.regionId));
+      if (regionTaken) continue;
+      deductCost(player.resources, SETTLEMENT_COST);
+      player.regionsControlled.push(action.regionId);
+      player.vp += 1;
+      player.influence += 1;
+    }
+  }
+
+  for (const ecosystem of ecosystems) {
+    const pressure = pressureByEcosystem.get(ecosystem.id) ?? 0;
+    const nextHealth = Math.max(0, Math.min(ecosystem.maxHealth, ecosystem.health + 2 - pressure));
+    ecosystem.health = nextHealth;
+  }
+
+  const flourishingEcosystems = ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'flourishing');
+  for (const ecosystem of flourishingEcosystems) {
+    for (const player of players) {
+      if (ecosystem.regionIds.some((regionId) => player.regionsControlled.includes(regionId))) {
+        player.influence += 1;
+      }
+    }
+  }
+
+  const rankings = [...players].sort((left, right) => {
+    if (right.vp !== left.vp) return right.vp - left.vp;
+    return right.influence - left.influence;
+  });
+  const winner = rankings[0]?.id ?? null;
+
+  return {
+    ...state,
+    players,
+    ecosystems,
+    activeTrades: completedTrades,
+    winner,
+  };
+}
+
+function advanceOrFinish(state: ComedyState): ActionResult<ComedyState, ComedyAction> {
+  if (state.round >= state.config.maxRounds) {
+    return {
+      state: { ...state, phase: 'finished' },
+      deadline: null,
+      progressIncrement: true,
+    };
+  }
+
+  return {
+    state: startRound(state),
+    deadline: {
+      seconds: state.config.turnTimerSeconds,
+      action: { type: 'round_timeout' },
+    },
+    progressIncrement: true,
+  };
+}
+
+export function createInitialState(config: ComedyConfig): ComedyState {
+  const regions = getBaseRegions();
+  return {
+    round: 0,
+    phase: 'waiting',
+    players: createPlayers(config.playerIds, regions),
+    regions,
+    ecosystems: getBaseEcosystems(),
+    activeTrades: [],
+    submittedActions: makeSubmittedActions(config.playerIds),
+    winner: null,
+    config,
+  };
+}
+
+export function validateAction(state: ComedyState, playerId: string | null, action: ComedyAction): boolean {
+  if (action.type === 'game_start') {
+    return playerId === null && state.phase === 'waiting';
+  }
+
+  if (action.type === 'round_timeout') {
+    return playerId === null && state.phase === 'playing';
+  }
+
+  if (playerId === null || state.phase !== 'playing') return false;
+  if (state.submittedActions[playerId] !== null) return false;
+  const player = state.players.find((item) => item.id === playerId);
+  if (!player) return false;
+
+  if (action.type === 'build_settlement') {
+    return Boolean(action.regionId && !player.regionsControlled.includes(action.regionId));
+  }
+
+  if (action.type === 'extract_commons') {
+    return Boolean(action.ecosystemId && EXTRACTION_PROFILES[action.level]);
+  }
+
+  return true;
+}
+
+export function applyAction(state: ComedyState, playerId: string | null, action: ComedyAction): ActionResult<ComedyState, ComedyAction> {
+  if (action.type === 'game_start') {
+    return {
+      state: startRound(state),
+      deadline: {
+        seconds: state.config.turnTimerSeconds,
+        action: { type: 'round_timeout' },
+      },
+      progressIncrement: true,
+    };
+  }
+
+  if (action.type === 'round_timeout') {
+    const completed = resolveRound({
+      ...state,
+      submittedActions: Object.fromEntries(
+        Object.entries(state.submittedActions).map(([id, submitted]) => [id, submitted ?? { type: 'pass' }]),
+      ),
+    });
+    return advanceOrFinish(completed);
+  }
+
+  if (!playerId) {
+    return { state };
+  }
+
+  const nextState: ComedyState = {
+    ...state,
+    submittedActions: {
+      ...state.submittedActions,
+      [playerId]: action,
+    },
+  };
+
+  if (!allPlayersSubmitted(nextState)) {
+    return { state: nextState };
+  }
+
+  const completed = resolveRound(nextState);
+  return advanceOrFinish(completed);
+}
+
+export interface ComedyPlayerView {
+  round: number;
+  maxRounds: number;
+  phase: ComedyState['phase'];
+  you: ComedyPlayerState;
+  scoreboard: Array<{ id: string; vp: number; influence: number; regionsControlled: number }>;
+  regions: ComedyRegion[];
+  ecosystems: Array<ComedyEcosystem & { status: ReturnType<typeof ecosystemStatus> }>;
+  activeTrades: ComedyTradeOffer[];
+  submitted: boolean;
+}
+
+export interface ComedySpectatorView {
+  round: number;
+  maxRounds: number;
+  phase: ComedyState['phase'];
+  players: Array<ComedyPlayerState & { totalResources: number }>;
+  regions: ComedyRegion[];
+  ecosystems: Array<ComedyEcosystem & { status: ReturnType<typeof ecosystemStatus> }>;
+  activeTrades: ComedyTradeOffer[];
+  winner: string | null;
+  handles: Record<string, string>;
+  relayMessages?: any[];
+}
+
+export function getPlayerView(state: ComedyState, playerId: string): ComedyPlayerView | null {
+  const player = state.players.find((item) => item.id === playerId);
+  if (!player) return null;
+  return {
+    round: state.round,
+    maxRounds: state.config.maxRounds,
+    phase: state.phase,
+    you: { ...player, resources: cloneResources(player.resources), regionsControlled: [...player.regionsControlled] },
+    scoreboard: state.players.map((item) => ({
+      id: item.id,
+      vp: item.vp,
+      influence: item.influence,
+      regionsControlled: item.regionsControlled.length,
+    })),
+    regions: state.regions.map((region) => ({ ...region, secondaryResources: [...region.secondaryResources], ecosystemIds: [...region.ecosystemIds] })),
+    ecosystems: state.ecosystems.map((ecosystem) => ({ ...ecosystem, regionIds: [...ecosystem.regionIds], status: ecosystemStatus(ecosystem) })),
+    activeTrades: state.activeTrades.map((offer) => ({ ...offer, give: { ...offer.give }, receive: { ...offer.receive } })),
+    submitted: state.submittedActions[playerId] !== null,
+  };
+}
+
+export function getSpectatorView(state: ComedyState, handles: Record<string, string>, relayMessages: any[] = []): ComedySpectatorView {
+  return {
+    round: state.round,
+    maxRounds: state.config.maxRounds,
+    phase: state.phase,
+    players: state.players.map((player) => ({
+      ...player,
+      resources: cloneResources(player.resources),
+      regionsControlled: [...player.regionsControlled],
+      totalResources: totalResources(player.resources),
+    })),
+    regions: state.regions.map((region) => ({ ...region, secondaryResources: [...region.secondaryResources], ecosystemIds: [...region.ecosystemIds] })),
+    ecosystems: state.ecosystems.map((ecosystem) => ({ ...ecosystem, regionIds: [...ecosystem.regionIds], status: ecosystemStatus(ecosystem) })),
+    activeTrades: state.activeTrades.map((offer) => ({ ...offer, give: { ...offer.give }, receive: { ...offer.receive } })),
+    winner: state.winner,
+    handles,
+    relayMessages,
+  };
+}
+
+export function getOutcome(state: ComedyState): ComedyOutcome {
+  const rankings = [...state.players]
+    .sort((left, right) => {
+      if (right.vp !== left.vp) return right.vp - left.vp;
+      return right.influence - left.influence;
+    })
+    .map((player) => ({ id: player.id, vp: player.vp, influence: player.influence }));
+
+  return {
+    rankings,
+    roundsPlayed: state.round,
+    flourishingEcosystems: state.ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'flourishing').length,
+    collapsedEcosystems: state.ecosystems.filter((ecosystem) => ecosystemStatus(ecosystem) === 'collapsed').length,
+  };
+}

--- a/packages/games/comedy-of-the-commons/src/game.ts
+++ b/packages/games/comedy-of-the-commons/src/game.ts
@@ -13,6 +13,14 @@ import {
   type ResourceType,
 } from './types.js';
 
+function toTradeOffer(action: Extract<ComedyAction, { type: 'offer_trade' }>): ComedyTradeOffer {
+  return {
+    to: action.to,
+    give: { ...action.give },
+    receive: { ...action.receive },
+  };
+}
+
 const RESOURCE_CAP = 14;
 const SETTLEMENT_COST: Partial<ResourceInventory> = {
   grain: 1,
@@ -203,28 +211,28 @@ function resolveTrades(
       const other = submittedByPlayer[j];
       if (other.action.type !== 'offer_trade' || used.has(j)) continue;
       if (current.playerId === other.playerId) continue;
-      if (current.action.offer.to !== other.playerId) continue;
-      if (other.action.offer.to !== current.playerId) continue;
-      if (!inventoryEquals(current.action.offer.give, other.action.offer.receive)) continue;
-      if (!inventoryEquals(current.action.offer.receive, other.action.offer.give)) continue;
+      if (current.action.to !== other.playerId) continue;
+      if (other.action.to !== current.playerId) continue;
+      if (!inventoryEquals(current.action.give, other.action.receive)) continue;
+      if (!inventoryEquals(current.action.receive, other.action.give)) continue;
 
       const actionSender = playerMap.get(current.playerId);
       const otherSender = playerMap.get(other.playerId);
       if (!actionSender || !otherSender) continue;
-      if (!canAfford(actionSender.resources, current.action.offer.give)) continue;
-      if (!canAfford(otherSender.resources, other.action.offer.give)) continue;
+      if (!canAfford(actionSender.resources, current.action.give)) continue;
+      if (!canAfford(otherSender.resources, other.action.give)) continue;
 
-      deductCost(actionSender.resources, current.action.offer.give);
-      deductCost(otherSender.resources, other.action.offer.give);
-      for (const [resource, amount] of Object.entries(current.action.offer.receive)) {
+      deductCost(actionSender.resources, current.action.give);
+      deductCost(otherSender.resources, other.action.give);
+      for (const [resource, amount] of Object.entries(current.action.receive)) {
         actionSender.resources[resource as ResourceType] += amount ?? 0;
       }
-      for (const [resource, amount] of Object.entries(other.action.offer.receive)) {
+      for (const [resource, amount] of Object.entries(other.action.receive)) {
         otherSender.resources[resource as ResourceType] += amount ?? 0;
       }
       actionSender.influence += 1;
       otherSender.influence += 1;
-      completed.push(current.action.offer, other.action.offer);
+      completed.push(toTradeOffer(current.action), toTradeOffer(other.action));
       used.add(i);
       used.add(j);
       break;
@@ -358,6 +366,10 @@ export function validateAction(state: ComedyState, playerId: string | null, acti
 
   if (action.type === 'extract_commons') {
     return Boolean(action.ecosystemId && EXTRACTION_PROFILES[action.level]);
+  }
+
+  if (action.type === 'offer_trade') {
+    return Boolean(action.to && action.to !== playerId);
   }
 
   return true;

--- a/packages/games/comedy-of-the-commons/src/index.ts
+++ b/packages/games/comedy-of-the-commons/src/index.ts
@@ -1,0 +1,26 @@
+export type {
+  ComedyAction,
+  ComedyConfig,
+  ComedyEcosystem,
+  ComedyOutcome,
+  ComedyPhase,
+  ComedyPlayerRanking,
+  ComedyPlayerState,
+  ComedyRegion,
+  ComedyState,
+  ComedyTradeOffer,
+  EcosystemKind,
+  ExtractionLevel,
+  ResourceInventory,
+  ResourceType,
+} from './types.js';
+
+export { DEFAULT_COMEDY_CONFIG, EMPTY_INVENTORY } from './types.js';
+export {
+  applyAction,
+  createInitialState,
+  getOutcome,
+  getPlayerView,
+  getSpectatorView,
+} from './game.js';
+export { ComedyOfTheCommonsPlugin } from './plugin.js';

--- a/packages/games/comedy-of-the-commons/src/index.ts
+++ b/packages/games/comedy-of-the-commons/src/index.ts
@@ -23,4 +23,4 @@ export {
   getPlayerView,
   getSpectatorView,
 } from './game.js';
-export { ComedyOfTheCommonsPlugin } from './plugin.js';
+export { ComedyOfTheCommonsPlugin, COMEDY_SYSTEM_ACTION_TYPES } from './plugin.js';

--- a/packages/games/comedy-of-the-commons/src/plugin.ts
+++ b/packages/games/comedy-of-the-commons/src/plugin.ts
@@ -1,0 +1,137 @@
+import type { CoordinationGame, GameSetup, SpectatorContext } from '@coordination-games/engine';
+import { OpenQueuePhase, registerGame } from '@coordination-games/engine';
+import {
+  DEFAULT_COMEDY_CONFIG,
+  type ComedyAction,
+  type ComedyConfig,
+  type ComedyOutcome,
+  type ComedyState,
+} from './types.js';
+import {
+  applyAction,
+  createInitialState,
+  getOutcome,
+  getPlayerView,
+  getSpectatorView,
+  validateAction,
+} from './game.js';
+
+const COMEDY_GUIDE = `# Comedy of the Commons — v0 Rules
+
+Comedy of the Commons is a free-for-all coordination game about shared scarcity.
+
+## Core loop
+- Each round begins with resource production from the regions you control.
+- You may submit one action per round.
+- Commons ecosystems can be extracted for short-term gain, but overuse degrades them.
+- You can expand by building settlements in unclaimed regions.
+- You can offer bilateral trades; reciprocal offers in the same round settle automatically.
+
+## Action types
+- \`offer_trade\`
+- \`extract_commons\`
+- \`build_settlement\`
+- \`pass\`
+
+## Win condition
+Highest VP wins when the round limit is reached. Influence is the tie-breaker.
+
+## Notes
+This is an intentionally reduced v0 upstream port. Richer trust, commitments, and Olympiad portability are planned for later slices.
+`;
+
+export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyState, ComedyAction, ComedyOutcome> = {
+  gameType: 'comedy-of-the-commons',
+  version: '0.1.0',
+  entryCost: 1,
+  spectatorDelay: 0,
+  guide: COMEDY_GUIDE,
+
+  lobby: {
+    queueType: 'open' as const,
+    phases: [new OpenQueuePhase(4)],
+    matchmaking: {
+      minPlayers: 4,
+      maxPlayers: 6,
+      teamSize: 1,
+      numTeams: 0,
+      queueTimeoutMs: 300000,
+    },
+  },
+
+  requiredPlugins: ['basic-chat'],
+  recommendedPlugins: ['rationale'],
+
+  createInitialState,
+
+  validateAction,
+
+  applyAction,
+
+  getVisibleState(state: ComedyState, playerId: string | null): unknown {
+    if (playerId === null) return getSpectatorView(state, {});
+    return getPlayerView(state, playerId) ?? getSpectatorView(state, {});
+  },
+
+  buildSpectatorView(state: ComedyState, _prevState: ComedyState | null, context: SpectatorContext): unknown {
+    return getSpectatorView(state, context.handles, context.relayMessages);
+  },
+
+  isOver(state: ComedyState): boolean {
+    return state.phase === 'finished';
+  },
+
+  getOutcome,
+
+  computePayouts(outcome: ComedyOutcome, playerIds: string[]): Map<string, number> {
+    const payouts = new Map<string, number>();
+    const topVp = outcome.rankings[0]?.vp ?? 0;
+    const winners = outcome.rankings.filter((ranking) => ranking.vp === topVp);
+    const winnerPayout = playerIds.length / Math.max(1, winners.length);
+    for (const id of playerIds) {
+      payouts.set(id, winners.some((winner) => winner.id === id) ? winnerPayout - 1 : -1);
+    }
+    return payouts;
+  },
+
+  getPlayerStatus(state: ComedyState, playerId: string): string {
+    const player = state.players.find((item) => item.id === playerId);
+    if (!player) return '\n## Your Status\n- Unknown player';
+    return `\n## Your Status\n- **Phase:** ${state.phase}\n- **Round:** ${state.round}/${state.config.maxRounds}\n- **VP:** ${player.vp}\n- **Influence:** ${player.influence}\n- **Controlled Regions:** ${player.regionsControlled.length}`;
+  },
+
+  getSummary(state: ComedyState): Record<string, any> {
+    return {
+      round: state.round,
+      maxRounds: state.config.maxRounds,
+      phase: state.phase,
+      players: state.players.map((player) => player.id),
+      flourishingEcosystems: state.ecosystems.filter((ecosystem) => ecosystem.health >= ecosystem.flourishThreshold).length,
+    };
+  },
+
+  getPlayersNeedingAction(state: ComedyState): string[] {
+    if (state.phase !== 'playing') return [];
+    return state.players
+      .filter((player) => state.submittedActions[player.id] === null)
+      .map((player) => player.id);
+  },
+
+  createConfig(
+    players: { id: string; handle: string; team?: string; role?: string }[],
+    seed: string,
+    options?: Record<string, any>,
+  ): GameSetup<ComedyConfig> {
+    return {
+      config: {
+        ...DEFAULT_COMEDY_CONFIG,
+        playerIds: players.map((player) => player.id),
+        seed,
+        ...(options?.maxRounds ? { maxRounds: options.maxRounds } : {}),
+      },
+      players: players.map((player) => ({ id: player.id, team: 'FFA' })),
+    };
+  },
+};
+
+registerGame(ComedyOfTheCommonsPlugin);

--- a/packages/games/comedy-of-the-commons/src/plugin.ts
+++ b/packages/games/comedy-of-the-commons/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { CoordinationGame, GameSetup, SpectatorContext } from '@coordination-games/engine';
+import type { CoordinationGame, GameSetup, SpectatorContext, ToolDefinition } from '@coordination-games/engine';
 import { OpenQueuePhase, registerGame } from '@coordination-games/engine';
 import {
   DEFAULT_COMEDY_CONFIG,
@@ -40,6 +40,66 @@ Highest VP wins when the round limit is reached. Influence is the tie-breaker.
 This is an intentionally reduced v0 upstream port. Richer trust, commitments, and Olympiad portability are planned for later slices.
 `;
 
+export const COMEDY_SYSTEM_ACTION_TYPES: readonly string[] = Object.freeze([
+  'game_start',
+  'round_timeout',
+]);
+
+const GAME_TOOLS: ToolDefinition[] = [
+  {
+    name: 'offer_trade',
+    description: 'Offer a bilateral trade to one other player. Matching reciprocal offers in the same round settle automatically.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        to: { type: 'string', description: 'Target player id for the trade offer.' },
+        give: { type: 'object', description: 'Resources you are offering.' },
+        receive: { type: 'object', description: 'Resources you want back.' },
+      },
+      required: ['to', 'give', 'receive'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'extract_commons',
+    description: 'Extract a shared resource from an ecosystem you can access. Higher extraction gives more now but damages the commons faster.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        ecosystemId: { type: 'string' },
+        level: { type: 'string', enum: ['low', 'medium', 'high'] },
+      },
+      required: ['ecosystemId', 'level'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'build_settlement',
+    description: 'Spend resources to establish a settlement in an unclaimed region and gain VP.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {
+        regionId: { type: 'string' },
+      },
+      required: ['regionId'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'pass',
+    description: 'Submit no action for this round.',
+    mcpExpose: true,
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];
+
 export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyState, ComedyAction, ComedyOutcome> = {
   gameType: 'comedy-of-the-commons',
   version: '0.1.0',
@@ -58,6 +118,8 @@ export const ComedyOfTheCommonsPlugin: CoordinationGame<ComedyConfig, ComedyStat
       queueTimeoutMs: 300000,
     },
   },
+
+  gameTools: GAME_TOOLS,
 
   requiredPlugins: ['basic-chat'],
   recommendedPlugins: ['rationale'],

--- a/packages/games/comedy-of-the-commons/src/types.ts
+++ b/packages/games/comedy-of-the-commons/src/types.ts
@@ -73,7 +73,7 @@ export interface ComedyTradeOffer {
 
 export type ComedyAction =
   | { type: 'game_start' }
-  | { type: 'offer_trade'; offer: ComedyTradeOffer }
+  | { type: 'offer_trade'; to: string; give: Partial<ResourceInventory>; receive: Partial<ResourceInventory> }
   | { type: 'extract_commons'; ecosystemId: string; level: ExtractionLevel }
   | { type: 'build_settlement'; regionId: string }
   | { type: 'pass' }

--- a/packages/games/comedy-of-the-commons/src/types.ts
+++ b/packages/games/comedy-of-the-commons/src/types.ts
@@ -1,0 +1,119 @@
+/**
+ * Comedy of the Commons — initial upstream v0 type surface.
+ *
+ * These types intentionally describe the smallest believable upstream Comedy
+ * shape, not the full local arena prototype.
+ */
+
+export type ComedyPhase = 'waiting' | 'playing' | 'finished';
+
+export type ResourceType =
+  | 'grain'
+  | 'timber'
+  | 'ore'
+  | 'fish'
+  | 'water'
+  | 'energy';
+
+export interface ResourceInventory {
+  grain: number;
+  timber: number;
+  ore: number;
+  fish: number;
+  water: number;
+  energy: number;
+}
+
+export const EMPTY_INVENTORY: ResourceInventory = {
+  grain: 0,
+  timber: 0,
+  ore: 0,
+  fish: 0,
+  water: 0,
+  energy: 0,
+};
+
+export type EcosystemKind = 'fishery' | 'forest' | 'aquifer' | 'wetland';
+
+export type ExtractionLevel = 'low' | 'medium' | 'high';
+
+export interface ComedyRegion {
+  id: string;
+  name: string;
+  primaryResource: ResourceType;
+  secondaryResources: ResourceType[];
+  ecosystemIds: string[];
+}
+
+export interface ComedyEcosystem {
+  id: string;
+  name: string;
+  kind: EcosystemKind;
+  resource: ResourceType;
+  regionIds: string[];
+  health: number;
+  maxHealth: number;
+  collapseThreshold: number;
+  flourishThreshold: number;
+}
+
+export interface ComedyPlayerState {
+  id: string;
+  resources: ResourceInventory;
+  influence: number;
+  vp: number;
+  regionsControlled: string[];
+}
+
+export interface ComedyTradeOffer {
+  to: string;
+  give: Partial<ResourceInventory>;
+  receive: Partial<ResourceInventory>;
+}
+
+export type ComedyAction =
+  | { type: 'game_start' }
+  | { type: 'offer_trade'; offer: ComedyTradeOffer }
+  | { type: 'extract_commons'; ecosystemId: string; level: ExtractionLevel }
+  | { type: 'build_settlement'; regionId: string }
+  | { type: 'pass' }
+  | { type: 'round_timeout' };
+
+export interface ComedyConfig {
+  seed: string;
+  playerIds: string[];
+  maxRounds: number;
+  turnTimerSeconds: number;
+}
+
+export interface ComedyState {
+  round: number;
+  phase: ComedyPhase;
+  players: ComedyPlayerState[];
+  regions: ComedyRegion[];
+  ecosystems: ComedyEcosystem[];
+  activeTrades: ComedyTradeOffer[];
+  submittedActions: Record<string, ComedyAction | null>;
+  winner: string | null;
+  config: ComedyConfig;
+}
+
+export interface ComedyPlayerRanking {
+  id: string;
+  vp: number;
+  influence: number;
+}
+
+export interface ComedyOutcome {
+  rankings: ComedyPlayerRanking[];
+  roundsPlayed: number;
+  flourishingEcosystems: number;
+  collapsedEcosystems: number;
+}
+
+export const DEFAULT_COMEDY_CONFIG: ComedyConfig = {
+  seed: 'comedy-v0',
+  playerIds: [],
+  maxRounds: 12,
+  turnTimerSeconds: 60,
+};

--- a/packages/games/comedy-of-the-commons/tsconfig.json
+++ b/packages/games/comedy-of-the-commons/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"],
+  "references": [
+    { "path": "../../engine" }
+  ]
+}

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;500;600;700;800&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
-    <title>Capture the Lobster 🦞</title>
+    <title>Coordination Games 🎮</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/web/src/components/Layout.tsx
+++ b/packages/web/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { NavLink, Outlet } from 'react-router-dom';
+import { PLATFORM_GITHUB_URL, PLATFORM_NAME, PLATFORM_SHORT_NAME } from '../games/manifest';
 
 function navLinkClass({ isActive }: { isActive: boolean }) {
   return `font-heading text-sm tracking-wider uppercase ${
@@ -22,12 +23,12 @@ export default function Layout() {
       }}>
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <NavLink to="/" className="flex items-center gap-2 sm:gap-3 hover:opacity-90 transition-opacity">
-            <span className="text-2xl sm:text-4xl" role="img" aria-label="lobster">
-              🦞
+            <span className="text-2xl sm:text-4xl" role="img" aria-label="games">
+              🎮
             </span>
             <h1 className="font-heading font-bold tracking-wide" style={{ color: 'var(--color-parchment)' }}>
-              <span className="hidden sm:inline text-xl">Capture the Lobster</span>
-              <span className="sm:hidden text-lg">CTL</span>
+              <span className="hidden sm:inline text-xl">{PLATFORM_NAME}</span>
+              <span className="sm:hidden text-lg">{PLATFORM_SHORT_NAME}</span>
             </h1>
           </NavLink>
 
@@ -43,7 +44,7 @@ export default function Layout() {
               Leaderboard
             </NavLink>
             <a
-              href="https://github.com/lucianHymer/capture-the-lobster"
+              href={PLATFORM_GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="transition-colors"
@@ -82,7 +83,7 @@ export default function Layout() {
               Leaderboard
             </NavLink>
             <a
-              href="https://github.com/lucianHymer/capture-the-lobster"
+              href={PLATFORM_GITHUB_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="font-heading text-sm tracking-wider uppercase transition-colors"

--- a/packages/web/src/components/lobby/JoinInstructions.tsx
+++ b/packages/web/src/components/lobby/JoinInstructions.tsx
@@ -1,14 +1,17 @@
 import { useState } from 'react';
+import { buildJoinPrompt, getGameDisplayName, PLATFORM_INSTALL_COMMAND } from '../../games/manifest';
 
-export default function JoinInstructions({ lobbyId }: { lobbyId: string }) {
+export default function JoinInstructions({ lobbyId, gameType }: { lobbyId: string; gameType?: string }) {
   const [copied, setCopied] = useState(false);
+  const gameName = getGameDisplayName(gameType);
+  const joinPrompt = buildJoinPrompt(lobbyId, gameType);
 
   function handleCopyInstall() {
-    navigator.clipboard.writeText('claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster').then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
+    navigator.clipboard.writeText(PLATFORM_INSTALL_COMMAND).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
   }
 
   function handleCopyJoinPrompt() {
-    navigator.clipboard.writeText(`Join lobby ${lobbyId} on Capture the Lobster and play, please!`).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
+    navigator.clipboard.writeText(joinPrompt).then(() => { setCopied(true); setTimeout(() => setCopied(false), 2000); });
   }
 
   return (
@@ -17,12 +20,12 @@ export default function JoinInstructions({ lobbyId }: { lobbyId: string }) {
       <p className="mb-2 text-xs" style={{ color: 'var(--color-ink-light)' }}>1. Install the plugin (one time):</p>
       <div onClick={handleCopyInstall} className="cursor-pointer rounded px-3 py-2 font-mono text-xs transition-colors hover:brightness-95" title="Click to copy"
         style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-ink-light)', border: '1px solid rgba(42, 31, 14, 0.08)' }}>
-        claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster
+        {PLATFORM_INSTALL_COMMAND}
       </div>
       <p className="mt-3 mb-2 text-xs" style={{ color: 'var(--color-ink-light)' }}>2. Tell your agent:</p>
       <div onClick={handleCopyJoinPrompt} className="cursor-pointer rounded px-3 py-2 font-mono text-xs transition-colors hover:brightness-95" title="Click to copy"
         style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-amber)', border: '1px solid rgba(184, 134, 11, 0.15)' }}>
-        "Join lobby {lobbyId} on Capture the Lobster and play, please!"
+        {`"Join lobby ${lobbyId} in Coordination Games and play ${gameName}, please!"`}
       </div>
       <p className="mt-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>{copied ? 'Copied!' : 'Click to copy'}</p>
     </div>

--- a/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
+++ b/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
@@ -54,14 +54,16 @@ function statusColor(status: ComedyEcosystem['status']): string {
 }
 
 export function ComedySpectatorView(props: SpectatorViewProps) {
-  const { gameId, handles, chatMessages } = props;
+  const { gameId, handles, chatMessages, gameState } = props;
   const [state, setState] = useState<ComedySpectatorState | null>(null);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const replayState = mapServerState(gameState);
+  const effectiveState = replayState ?? state;
 
   useEffect(() => {
-    if (!gameId) return;
+    if (!gameId || replayState) return;
 
     fetch(`${API_BASE}/games/${gameId}`)
       .then((r) => r.json())
@@ -89,14 +91,14 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
       ws.close();
       wsRef.current = null;
     };
-  }, [gameId]);
+  }, [gameId, replayState]);
 
   const sortedPlayers = useMemo(
-    () => [...(state?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
-    [state?.players],
+    () => [...(effectiveState?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
+    [effectiveState?.players],
   );
 
-  if (!state) {
+  if (!effectiveState) {
     return (
       <div className="flex h-[calc(100vh-5rem)] items-center justify-center px-6 text-center">
         <div>
@@ -114,10 +116,10 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
           <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
             <div>
               <h1 className="text-xl font-semibold text-emerald-200">Comedy of the Commons</h1>
-              <p className="text-sm text-slate-400">Round {state.round}/{state.maxRounds} · {state.phase}</p>
+              <p className="text-sm text-slate-400">Round {effectiveState.round}/{effectiveState.maxRounds} · {effectiveState.phase}</p>
             </div>
             <div className="rounded-full border border-emerald-500/20 px-3 py-1 text-xs uppercase tracking-[0.2em] text-emerald-300">
-              {state.winner ? `Leader: ${handles[state.winner] ?? state.winner}` : 'Live commons race'}
+              {effectiveState.winner ? `Leader: ${handles[effectiveState.winner] ?? effectiveState.winner}` : 'Live commons race'}
             </div>
           </div>
 
@@ -154,7 +156,7 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
           <section className="rounded-2xl border border-sky-500/20 bg-slate-900/80 p-5 shadow-xl">
             <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Ecosystems</h2>
             <div className="space-y-3">
-              {state.ecosystems.map((ecosystem) => {
+              {effectiveState.ecosystems.map((ecosystem) => {
                 const pct = Math.max(0, Math.min(100, Math.round((ecosystem.health / ecosystem.maxHealth) * 100)));
                 return (
                   <div key={ecosystem.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
@@ -177,11 +179,11 @@ export function ComedySpectatorView(props: SpectatorViewProps) {
 
           <section className="rounded-2xl border border-amber-500/20 bg-slate-900/80 p-5 shadow-xl">
             <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Active trades</h2>
-            {state.activeTrades.length === 0 ? (
+            {effectiveState.activeTrades.length === 0 ? (
               <p className="text-sm text-slate-400">No reciprocal trades settled this round.</p>
             ) : (
               <div className="space-y-2 text-sm text-slate-300">
-                {state.activeTrades.map((trade, index) => (
+                {effectiveState.activeTrades.map((trade, index) => (
                   <div key={`${trade.to}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
                     <div className="text-xs uppercase tracking-[0.14em] text-slate-500">to {handles[trade.to] ?? trade.to}</div>
                     <div>Give {JSON.stringify(trade.give)} · Receive {JSON.stringify(trade.receive)}</div>

--- a/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
+++ b/packages/web/src/games/comedy-of-the-commons/SpectatorView.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { SpectatorViewProps } from '../types';
+import { API_BASE, getWsUrl } from '../../config.js';
+
+interface ComedyPlayer {
+  id: string;
+  vp: number;
+  influence: number;
+  totalResources: number;
+  resources: Record<string, number>;
+  regionsControlled: string[];
+}
+
+interface ComedyEcosystem {
+  id: string;
+  name: string;
+  resource: string;
+  health: number;
+  maxHealth: number;
+  status: 'flourishing' | 'stable' | 'strained' | 'collapsed';
+}
+
+interface ComedySpectatorState {
+  round: number;
+  maxRounds: number;
+  phase: 'waiting' | 'playing' | 'finished';
+  winner: string | null;
+  players: ComedyPlayer[];
+  ecosystems: ComedyEcosystem[];
+  activeTrades: Array<{ to: string; give: Record<string, number>; receive: Record<string, number> }>;
+}
+
+function mapServerState(raw: any): ComedySpectatorState | null {
+  const data = raw?.data ?? raw;
+  if (!data?.players || !Array.isArray(data.players) || !Array.isArray(data.ecosystems)) return null;
+  return {
+    round: data.round ?? 0,
+    maxRounds: data.maxRounds ?? data.config?.maxRounds ?? 12,
+    phase: data.phase ?? 'waiting',
+    winner: data.winner ?? null,
+    players: data.players,
+    ecosystems: data.ecosystems,
+    activeTrades: data.activeTrades ?? [],
+  };
+}
+
+function statusColor(status: ComedyEcosystem['status']): string {
+  switch (status) {
+    case 'flourishing': return '#7bd88f';
+    case 'strained': return '#f6c177';
+    case 'collapsed': return '#ef6b73';
+    default: return '#8ecae6';
+  }
+}
+
+export function ComedySpectatorView(props: SpectatorViewProps) {
+  const { gameId, handles, chatMessages } = props;
+  const [state, setState] = useState<ComedySpectatorState | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!gameId) return;
+
+    fetch(`${API_BASE}/games/${gameId}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const mapped = mapServerState(data);
+        if (mapped) setState(mapped);
+      })
+      .catch(() => setError('Failed to load Comedy game state'));
+
+    const ws = new WebSocket(getWsUrl(`/ws/game/${gameId}`));
+    wsRef.current = ws;
+    ws.onopen = () => { setConnected(true); setError(null); };
+    ws.onclose = () => setConnected(false);
+    ws.onerror = () => setError('WebSocket error');
+    ws.onmessage = (event) => {
+      try {
+        const mapped = mapServerState(JSON.parse(event.data));
+        if (mapped) setState(mapped);
+      } catch {
+        // Ignore malformed spectator updates.
+      }
+    };
+
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [gameId]);
+
+  const sortedPlayers = useMemo(
+    () => [...(state?.players ?? [])].sort((a, b) => (b.vp - a.vp) || (b.influence - a.influence)),
+    [state?.players],
+  );
+
+  if (!state) {
+    return (
+      <div className="flex h-[calc(100vh-5rem)] items-center justify-center px-6 text-center">
+        <div>
+          <div className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-emerald-300">Comedy of the Commons</div>
+          <p className="text-sm text-slate-300">{error ?? (connected ? 'Waiting for game state…' : 'Connecting…')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-5rem)] bg-slate-950 px-6 py-6 text-slate-100">
+      <div className="mx-auto grid max-w-7xl gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-2xl border border-emerald-500/20 bg-slate-900/80 p-5 shadow-xl">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="text-xl font-semibold text-emerald-200">Comedy of the Commons</h1>
+              <p className="text-sm text-slate-400">Round {state.round}/{state.maxRounds} · {state.phase}</p>
+            </div>
+            <div className="rounded-full border border-emerald-500/20 px-3 py-1 text-xs uppercase tracking-[0.2em] text-emerald-300">
+              {state.winner ? `Leader: ${handles[state.winner] ?? state.winner}` : 'Live commons race'}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            {sortedPlayers.map((player) => {
+              const name = handles[player.id] ?? player.id;
+              return (
+                <article key={player.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+                  <div className="mb-2 flex items-center justify-between gap-3">
+                    <div>
+                      <h2 className="font-medium text-emerald-100">{name}</h2>
+                      <p className="text-xs uppercase tracking-[0.18em] text-slate-500">{player.regionsControlled.length} regions · {player.totalResources} resources</p>
+                    </div>
+                    <div className="text-right text-xs text-slate-300">
+                      <div>VP {player.vp}</div>
+                      <div>Inf {player.influence}</div>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-3 gap-2 text-xs text-slate-300">
+                    {Object.entries(player.resources).map(([resource, amount]) => (
+                      <div key={resource} className="rounded-lg bg-slate-900/80 px-2 py-1">
+                        <div className="uppercase tracking-[0.12em] text-slate-500">{resource}</div>
+                        <div className="font-medium text-slate-100">{amount}</div>
+                      </div>
+                    ))}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <aside className="space-y-6">
+          <section className="rounded-2xl border border-sky-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Ecosystems</h2>
+            <div className="space-y-3">
+              {state.ecosystems.map((ecosystem) => {
+                const pct = Math.max(0, Math.min(100, Math.round((ecosystem.health / ecosystem.maxHealth) * 100)));
+                return (
+                  <div key={ecosystem.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-3">
+                    <div className="mb-2 flex items-center justify-between gap-2 text-sm">
+                      <span className="font-medium text-slate-100">{ecosystem.name}</span>
+                      <span className="text-xs uppercase tracking-[0.18em]" style={{ color: statusColor(ecosystem.status) }}>{ecosystem.status}</span>
+                    </div>
+                    <div className="mb-2 h-2 rounded-full bg-slate-800">
+                      <div className="h-2 rounded-full" style={{ width: `${pct}%`, background: statusColor(ecosystem.status) }} />
+                    </div>
+                    <div className="flex items-center justify-between text-xs text-slate-400">
+                      <span>{ecosystem.resource}</span>
+                      <span>{ecosystem.health}/{ecosystem.maxHealth}</span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-amber-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amber-300">Active trades</h2>
+            {state.activeTrades.length === 0 ? (
+              <p className="text-sm text-slate-400">No reciprocal trades settled this round.</p>
+            ) : (
+              <div className="space-y-2 text-sm text-slate-300">
+                {state.activeTrades.map((trade, index) => (
+                  <div key={`${trade.to}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
+                    <div className="text-xs uppercase tracking-[0.14em] text-slate-500">to {handles[trade.to] ?? trade.to}</div>
+                    <div>Give {JSON.stringify(trade.give)} · Receive {JSON.stringify(trade.receive)}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-violet-500/20 bg-slate-900/80 p-5 shadow-xl">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-violet-300">Public chat</h2>
+            <div className="space-y-2 text-sm text-slate-300">
+              {chatMessages.length === 0 ? (
+                <p className="text-slate-400">No public messages yet.</p>
+              ) : (
+                chatMessages.slice(-8).map((message, index) => (
+                  <div key={`${message.timestamp}-${index}`} className="rounded-xl border border-slate-800 bg-slate-950/70 px-3 py-2">
+                    <div className="mb-1 text-xs uppercase tracking-[0.14em] text-slate-500">{handles[message.from] ?? message.from}</div>
+                    <div>{message.message}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/games/comedy-of-the-commons/index.ts
+++ b/packages/web/src/games/comedy-of-the-commons/index.ts
@@ -1,0 +1,9 @@
+import type { SpectatorPlugin } from '../types';
+import { ComedySpectatorView } from './SpectatorView';
+
+export const ComedyOfTheCommonsSpectator: SpectatorPlugin = {
+  gameType: 'comedy-of-the-commons',
+  displayName: 'Comedy of the Commons',
+  SpectatorView: ComedySpectatorView,
+  animationDuration: 1200,
+};

--- a/packages/web/src/games/manifest.ts
+++ b/packages/web/src/games/manifest.ts
@@ -57,6 +57,12 @@ const GAME_MANIFEST: GameManifestEntry[] = [
     tagline: 'Resource management, trade, and reputation',
     availability: 'prototype',
     accentColor: '#34d399',
+    lobby: {
+      options: [4, 5, 6],
+      optionDisplay: 'count',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Players',
+    },
   },
   {
     gameType: 'ai-alignment',

--- a/packages/web/src/games/manifest.ts
+++ b/packages/web/src/games/manifest.ts
@@ -1,0 +1,95 @@
+export type GameAvailability = 'live' | 'prototype' | 'concept';
+export type LobbyOptionDisplay = 'versus' | 'count';
+
+export interface GameManifestEntry {
+  gameType: string;
+  displayName: string;
+  shortName: string;
+  tagline: string;
+  availability: GameAvailability;
+  accentColor: string;
+  lobby?: {
+    options: number[];
+    optionDisplay: LobbyOptionDisplay;
+    buttonLabel: string;
+    metricLabel: string;
+  };
+}
+
+export const PLATFORM_NAME = 'Coordination Games';
+export const PLATFORM_SHORT_NAME = 'CG';
+export const PLATFORM_INSTALL_COMMAND = 'npx skills add -g lucianHymer/coordination';
+export const PLATFORM_GITHUB_URL = 'https://github.com/coordination-games/coordination-games';
+
+const GAME_MANIFEST: GameManifestEntry[] = [
+  {
+    gameType: 'capture-the-lobster',
+    displayName: 'Capture the Lobster',
+    shortName: 'CtL',
+    tagline: 'Team tactics under fog of war',
+    availability: 'live',
+    accentColor: 'var(--color-forest)',
+    lobby: {
+      options: [2, 3, 4, 5, 6],
+      optionDisplay: 'versus',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Teams',
+    },
+  },
+  {
+    gameType: 'oathbreaker',
+    displayName: 'OATHBREAKER',
+    shortName: 'OATH',
+    tagline: 'Iterated trust under real stakes',
+    availability: 'live',
+    accentColor: 'var(--color-blood)',
+    lobby: {
+      options: [4, 6, 8, 10, 12, 16, 20],
+      optionDisplay: 'count',
+      buttonLabel: 'Create Lobby',
+      metricLabel: 'Players',
+    },
+  },
+  {
+    gameType: 'comedy-of-the-commons',
+    displayName: 'Comedy of the Commons',
+    shortName: 'Comedy',
+    tagline: 'Resource management, trade, and reputation',
+    availability: 'prototype',
+    accentColor: '#34d399',
+  },
+  {
+    gameType: 'ai-alignment',
+    displayName: 'AI Alignment',
+    shortName: 'Alignment',
+    tagline: 'Coordination under existential pressure',
+    availability: 'concept',
+    accentColor: '#fb7185',
+  },
+];
+
+export function getAllGameManifest(): GameManifestEntry[] {
+  return GAME_MANIFEST;
+}
+
+export function getLobbyEnabledGames(): GameManifestEntry[] {
+  return GAME_MANIFEST.filter((game) => game.lobby);
+}
+
+export function getGameManifest(gameType?: string | null): GameManifestEntry | undefined {
+  if (!gameType) return undefined;
+  return GAME_MANIFEST.find((game) => game.gameType === gameType);
+}
+
+export function getGameDisplayName(gameType?: string | null): string {
+  return getGameManifest(gameType)?.displayName ?? 'Unknown Game';
+}
+
+export function formatLobbyOption(game: GameManifestEntry, value: number): string {
+  if (!game.lobby) return String(value);
+  return game.lobby.optionDisplay === 'versus' ? `${value}v${value}` : String(value);
+}
+
+export function buildJoinPrompt(lobbyId: string, gameType?: string | null): string {
+  return `Join lobby ${lobbyId} in ${PLATFORM_NAME} and play ${getGameDisplayName(gameType)}, please!`;
+}

--- a/packages/web/src/games/registry.ts
+++ b/packages/web/src/games/registry.ts
@@ -1,8 +1,10 @@
 import type { SpectatorPlugin } from './types';
+import { ComedyOfTheCommonsSpectator } from './comedy-of-the-commons';
 import { CaptureTheLobsterSpectator } from './capture-the-lobster';
 import { OathbreakerSpectator } from './oathbreaker';
 
 const SPECTATOR_PLUGINS: Record<string, SpectatorPlugin> = {
+  'comedy-of-the-commons': ComedyOfTheCommonsSpectator,
   'capture-the-lobster': CaptureTheLobsterSpectator,
   'oathbreaker': OathbreakerSpectator,
 };

--- a/packages/web/src/pages/GamePage.tsx
+++ b/packages/web/src/pages/GamePage.tsx
@@ -53,7 +53,7 @@ export default function GamePage() {
     fetch(`${API_BASE}/games/${id}`)
       .then(r => r.json())
       .then(data => {
-        setGameType(data.gameType ?? 'capture-the-lobster');
+        setGameType(data.gameType ?? 'unknown');
         const h = extractHandles(data);
         if (Object.keys(h).length) setHandles(h);
         const c = extractChat(data);
@@ -61,7 +61,7 @@ export default function GamePage() {
         setLoading(false);
       })
       .catch(() => {
-        setGameType('capture-the-lobster');
+        setGameType('unknown');
         setLoading(false);
       });
 

--- a/packages/web/src/pages/HomePage.tsx
+++ b/packages/web/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { fetchGames } from '../api';
+import { getAllGameManifest, PLATFORM_INSTALL_COMMAND, PLATFORM_NAME } from '../games/manifest';
 
 function CopyBlock({ text, display }: { text: string; display?: string }) {
   const [copied, setCopied] = useState(false);
@@ -56,6 +57,7 @@ const fadeUp = {
 
 export default function HomePage() {
   const [activeCount, setActiveCount] = useState(0);
+  const featuredGames = getAllGameManifest().filter((game) => game.availability === 'live');
 
   useEffect(() => {
     let cancelled = false;
@@ -116,33 +118,38 @@ export default function HomePage() {
         />
 
         <div className="relative z-10 px-8 py-12 sm:px-12 sm:py-16 space-y-8">
-          {/* Unit sprites */}
+          {/* Featured games */}
           <motion.div className="flex justify-center gap-6 mb-2" variants={fadeUp}>
-            {['rogue', 'knight', 'mage'].map((unit, i) => (
-              <motion.img
-                key={unit}
-                src={`/tiles/units/${unit}.png`}
-                alt={unit}
-                className="w-24 h-24 sm:w-32 sm:h-32"
-                style={{ imageRendering: 'pixelated', filter: 'drop-shadow(0 0 8px rgba(212, 162, 78, 0.4))' }}
+            {featuredGames.map((game, i) => (
+              <motion.div
+                key={game.gameType}
+                className="rounded-full px-4 py-2 text-xs font-heading font-semibold uppercase tracking-[0.2em]"
+                style={{
+                  color: game.accentColor,
+                  background: 'rgba(212, 162, 78, 0.06)',
+                  border: `1px solid ${game.accentColor}55`,
+                  boxShadow: `0 0 8px ${game.accentColor}22`,
+                }}
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.2 + i * 0.12, duration: 0.5 }}
-              />
+              >
+                {game.displayName}
+              </motion.div>
             ))}
           </motion.div>
 
           {/* Title */}
           <motion.div className="text-center space-y-2" variants={fadeUp}>
             <h2 className="font-heading text-3xl sm:text-4xl font-bold tracking-wide leading-tight" style={{ color: 'var(--color-parchment)' }}>
-              Capture the Lobster
+              {PLATFORM_NAME}
             </h2>
             <p className="font-heading text-sm sm:text-base tracking-wide leading-relaxed max-w-lg mx-auto" style={{ color: 'var(--color-parchment-dark)' }}>
-              A game where agents learn to find teammates, coordinate,
-              and actually get things done together.
+              A platform for multiplayer agent games where strategy,
+              coordination, and reputation can evolve across repeated play.
             </p>
             <p className="font-heading text-sm sm:text-base tracking-wide" style={{ color: 'var(--color-amber-glow)' }}>
-              You — and your agents — build the tools.
+              Bring your agents. Build better harnesses. Study what wins.
             </p>
           </motion.div>
 
@@ -161,14 +168,14 @@ export default function HomePage() {
                 <span className="flex-none w-4 h-4 rounded-full text-[9px] font-bold flex items-center justify-center font-heading" style={{ background: 'rgba(212, 162, 78, 0.2)', color: 'var(--color-amber-glow)' }}>1</span>
                 <span className="font-heading text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-amber-dim)' }}>Install the MCP skill</span>
               </div>
-              <CopyBlock text="claude mcp add --scope user --transport http capture-the-lobster https://capturethelobster.com/mcp && npx -y allow-mcp capture-the-lobster" />
+              <CopyBlock text={PLATFORM_INSTALL_COMMAND} />
             </div>
             <div className="space-y-1.5">
               <div className="flex items-center gap-2">
                 <span className="flex-none w-4 h-4 rounded-full text-[9px] font-bold flex items-center justify-center font-heading" style={{ background: 'rgba(212, 162, 78, 0.2)', color: 'var(--color-amber-glow)' }}>2</span>
                 <span className="font-heading text-[11px] font-semibold uppercase tracking-wider" style={{ color: 'var(--color-amber-dim)' }}>Ask your agent</span>
               </div>
-              <CopyBlock text="Tell me about Capture the Lobster, please!" display={'"Tell me about Capture the Lobster, please!"'} />
+              <CopyBlock text="Show me the live games in Coordination Games and help me join a lobby." display={'"Show me the live games in Coordination Games and help me join a lobby."'} />
             </div>
           </motion.div>
         </div>

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -24,10 +24,17 @@ interface Lobby {
   lobbyId: string;
   gameType?: string;
   phase: 'running' | 'starting' | 'game' | 'failed';
-  teamSize?: number;
   playerCount?: number;
-  createdAt?: string;
+  currentPhase?: {
+    id: string;
+    name: string;
+    view: any;
+  } | null;
+  agents: any[];
+  deadlineMs?: number | null;
   gameId?: string | null;
+  error?: string | null;
+  noTimeout?: boolean;
 }
 
 function phaseBadge(phase: string) {
@@ -248,7 +255,7 @@ function lobbyPhaseBadge(lobby: Lobby) {
       return (
         <span className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-heading font-medium tracking-wide" style={{ background: 'rgba(184, 134, 11, 0.08)', color: 'var(--color-amber)', border: '1px solid rgba(184, 134, 11, 0.2)' }}>
           <span className="h-1.5 w-1.5 rounded-full animate-pulse" style={{ background: 'var(--color-amber)' }} />
-          Open
+          {phaseName ?? 'In Progress'}
         </span>
       );
     case 'starting':

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -61,8 +61,9 @@ export default function LobbiesPage() {
   const [lobbies, setLobbies] = useState<Lobby[]>([]);
   const [creating, setCreating] = useState(false);
   const [teamSize, setTeamSize] = useState(2);
-  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker'>('capture-the-lobster');
+  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker' | 'comedy-of-the-commons'>('capture-the-lobster');
   const [oathPlayerCount, setOathPlayerCount] = useState(4);
+  const [comedyPlayerCount, setComedyPlayerCount] = useState(4);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -104,6 +105,12 @@ export default function LobbiesPage() {
         const res = await fetch(`${API_BASE}/lobbies/create`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ gameType: 'oathbreaker', playerCount: oathPlayerCount }),
+        });
+        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
+      } else if (gameTab === 'comedy-of-the-commons') {
+        const res = await fetch(`${API_BASE}/lobbies/create`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ gameType: 'comedy-of-the-commons', teamSize: comedyPlayerCount }),
         });
         if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
       } else {
@@ -148,6 +155,16 @@ export default function LobbiesPage() {
           >
             OATHBREAKER
           </button>
+          <button
+            onClick={() => setGameTab('comedy-of-the-commons')}
+            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
+            style={gameTab === 'comedy-of-the-commons'
+              ? { background: 'rgba(16, 185, 129, 0.12)', color: '#86efac', border: '1px solid rgba(16, 185, 129, 0.35)' }
+              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+            }
+          >
+            Comedy of the Commons
+          </button>
         </div>
 
         {/* Create controls */}
@@ -168,7 +185,7 @@ export default function LobbiesPage() {
                 </button>
               ))}
             </div>
-          ) : (
+          ) : gameTab === 'oathbreaker' ? (
             <div className="flex items-center gap-2">
               <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
               {[4, 6, 8, 10, 12, 16, 20].map((count) => (
@@ -178,6 +195,23 @@ export default function LobbiesPage() {
                   className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
                   style={oathPlayerCount === count
                     ? { background: 'rgba(139, 32, 32, 0.15)', color: 'var(--color-blood-light, #c55)', border: '1px solid rgba(139, 32, 32, 0.4)' }
+                    : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+                  }
+                >
+                  {count}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
+              {[4, 5, 6].map((count) => (
+                <button
+                  key={count}
+                  onClick={() => setComedyPlayerCount(count)}
+                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
+                  style={comedyPlayerCount === count
+                    ? { background: 'rgba(16, 185, 129, 0.15)', color: '#86efac', border: '1px solid rgba(16, 185, 129, 0.4)' }
                     : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
                   }
                 >
@@ -312,12 +346,58 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
         {gameType === 'oathbreaker' && (
           <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>OATHBREAKER</span>
         )}
+        {gameType === 'comedy-of-the-commons' && (
+          <span className="font-heading text-xs font-medium" style={{ color: '#86efac' }}>COMEDY</span>
+        )}
       </div>
     </button>
   );
 }
 
 function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
+  if (game.gameType === 'comedy-of-the-commons') {
+    const round = game.round ?? game.turn ?? 0;
+    const maxRounds = game.maxRounds ?? game.maxTurns ?? 12;
+    const progress = maxRounds > 0 ? Math.round((round / maxRounds) * 100) : 0;
+    const isLive = game.phase === 'playing' || game.phase === 'in_progress';
+    return (
+      <button onClick={onClick} className="group cursor-pointer w-full rounded-xl parchment-strong p-5 text-left transition-all duration-200 hover:shadow-md">
+        <div className="mb-3 flex items-center justify-between">
+          <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>{game.id}</span>
+          {phaseBadge(isLive ? 'in_progress' : game.phase === 'finished' ? 'finished' : 'starting')}
+        </div>
+        <div className="mb-3">
+          <div className="mb-1.5 flex justify-between text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>
+            <span>Round {round}/{maxRounds}</span>
+            <span>{progress}%</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full" style={{ background: 'rgba(42, 31, 14, 0.08)' }}>
+            <motion.div
+              className="h-1.5 rounded-full"
+              style={{
+                width: `${progress}%`,
+                background: isLive
+                  ? 'linear-gradient(90deg, #10b981, #86efac)'
+                  : 'linear-gradient(90deg, var(--color-ink-faint), var(--color-wood-light))',
+              }}
+              initial={{ width: 0 }}
+              animate={{ width: `${progress}%` }}
+              transition={{ duration: 0.8, ease: 'easeOut' }}
+            />
+          </div>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-heading text-xs font-medium" style={{ color: '#86efac' }}>
+            Comedy of the Commons
+          </span>
+          <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>
+            {game.playerCount ?? '?'} players
+          </span>
+        </div>
+      </button>
+    );
+  }
+
   // OATHBREAKER game card
   if (game.gameType === 'oathbreaker') {
     const round = game.round ?? game.turn ?? 0;

--- a/packages/web/src/pages/LobbiesPage.tsx
+++ b/packages/web/src/pages/LobbiesPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { API_BASE } from '../config.js';
 import { motion } from 'framer-motion';
 import { fetchGames, type GameSummary } from '../api';
+import { formatLobbyOption, getGameManifest, getLobbyEnabledGames } from '../games/manifest';
 
 interface Game {
   id: string;
@@ -57,13 +58,19 @@ function phaseBadge(phase: string) {
 }
 
 export default function LobbiesPage() {
+  const lobbyGames = getLobbyEnabledGames();
+  const defaultGame = lobbyGames[0]?.gameType ?? 'capture-the-lobster';
   const [games, setGames] = useState<Game[]>([]);
   const [lobbies, setLobbies] = useState<Lobby[]>([]);
   const [creating, setCreating] = useState(false);
-  const [teamSize, setTeamSize] = useState(2);
-  const [gameTab, setGameTab] = useState<'capture-the-lobster' | 'oathbreaker'>('capture-the-lobster');
-  const [oathPlayerCount, setOathPlayerCount] = useState(4);
+  const [gameTab, setGameTab] = useState<string>(defaultGame);
+  const [createValue, setCreateValue] = useState<number>(getGameManifest(defaultGame)?.lobby?.options[0] ?? 2);
   const navigate = useNavigate();
+  const selectedGame = getGameManifest(gameTab);
+
+  useEffect(() => {
+    setCreateValue(selectedGame?.lobby?.options[0] ?? 2);
+  }, [selectedGame?.gameType]);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,25 +107,17 @@ export default function LobbiesPage() {
   async function handleCreateLobby() {
     setCreating(true);
     try {
-      if (gameTab === 'oathbreaker') {
-        const res = await fetch(`${API_BASE}/lobbies/create`, {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ gameType: 'oathbreaker', playerCount: oathPlayerCount }),
-        });
-        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
-      } else {
-        const res = await fetch(`${API_BASE}/lobbies/create`, {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ teamSize }),
-        });
-        if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
-      }
+      const res = await fetch(`${API_BASE}/lobbies/create`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ gameType: gameTab, teamSize: createValue }),
+      });
+      if (res.ok) { const data = await res.json(); navigate(`/lobby/${data.lobbyId}`); return; }
     } catch {}
     setCreating(false);
   }
 
-  const filteredGames = games.filter(g => (g.gameType ?? 'capture-the-lobster') === gameTab);
-  const filteredLobbies = lobbies.filter(l => (l.gameType ?? 'capture-the-lobster') === gameTab);
+  const filteredGames = games.filter(g => (g.gameType ?? defaultGame) === gameTab);
+  const filteredLobbies = lobbies.filter(l => (l.gameType ?? defaultGame) === gameTab);
   const activeGames = filteredGames.filter((g) => g.phase !== 'finished');
   const finishedGames = filteredGames.filter((g) => g.phase === 'finished');
 
@@ -128,60 +127,40 @@ export default function LobbiesPage() {
       <div className="flex flex-col gap-3">
         {/* Tab selector */}
         <div className="flex items-center gap-2">
-          <button
-            onClick={() => setGameTab('capture-the-lobster')}
-            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
-            style={gameTab === 'capture-the-lobster'
-              ? { background: 'rgba(58, 90, 42, 0.15)', color: 'var(--color-forest)', border: '1px solid rgba(58, 90, 42, 0.3)' }
-              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-            }
-          >
-            Capture the Lobster
-          </button>
-          <button
-            onClick={() => setGameTab('oathbreaker')}
-            className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
-            style={gameTab === 'oathbreaker'
-              ? { background: 'rgba(139, 32, 32, 0.12)', color: 'var(--color-blood)', border: '1px solid rgba(139, 32, 32, 0.3)' }
-              : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-            }
-          >
-            OATHBREAKER
-          </button>
+          {lobbyGames.map((game) => {
+            const isActive = gameTab === game.gameType;
+            return (
+              <button
+                key={game.gameType}
+                onClick={() => setGameTab(game.gameType)}
+                className="cursor-pointer rounded-lg px-4 py-2 text-sm font-heading font-semibold tracking-wide transition-all"
+                style={isActive
+                  ? { background: `${game.accentColor}20`, color: game.accentColor, border: `1px solid ${game.accentColor}55` }
+                  : { background: 'transparent', color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
+                }
+              >
+                {game.displayName}
+              </button>
+            );
+          })}
         </div>
 
         {/* Create controls */}
         <div className="flex items-center justify-end gap-3">
-          {gameTab === 'capture-the-lobster' ? (
+          {selectedGame?.lobby && (
             <div className="flex items-center gap-2">
-              {[2, 3, 4, 5, 6].map((size) => (
+              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>{selectedGame.lobby.metricLabel}:</span>
+              {selectedGame.lobby.options.map((option) => (
                 <button
-                  key={size}
-                  onClick={() => setTeamSize(size)}
-                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
-                  style={teamSize === size
-                    ? { background: 'rgba(212, 162, 78, 0.15)', color: 'var(--color-amber-glow)', border: '1px solid rgba(212, 162, 78, 0.4)' }
+                  key={option}
+                  onClick={() => setCreateValue(option)}
+                  className="cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors"
+                  style={createValue === option
+                    ? { background: `${selectedGame.accentColor}20`, color: selectedGame.accentColor, border: `1px solid ${selectedGame.accentColor}55` }
                     : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
                   }
                 >
-                  {size}v{size}
-                </button>
-              ))}
-            </div>
-          ) : (
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-mono" style={{ color: 'var(--color-ink-faint)' }}>Players:</span>
-              {[4, 6, 8, 10, 12, 16, 20].map((count) => (
-                <button
-                  key={count}
-                  onClick={() => setOathPlayerCount(count)}
-                  className={`cursor-pointer rounded-md px-2.5 py-1 text-xs font-mono font-medium transition-colors`}
-                  style={oathPlayerCount === count
-                    ? { background: 'rgba(139, 32, 32, 0.15)', color: 'var(--color-blood-light, #c55)', border: '1px solid rgba(139, 32, 32, 0.4)' }
-                    : { color: 'var(--color-ink-faint)', border: '1px solid rgba(42, 31, 14, 0.15)' }
-                  }
-                >
-                  {count}
+                  {formatLobbyOption(selectedGame, option)}
                 </button>
               ))}
             </div>
@@ -194,7 +173,7 @@ export default function LobbiesPage() {
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
-            {creating ? 'Creating...' : 'Create Lobby'}
+            {creating ? 'Creating...' : (selectedGame?.lobby?.buttonLabel ?? 'Create Lobby')}
           </motion.button>
         </div>
       </div>
@@ -262,6 +241,7 @@ function SectionHeader({ title, count }: { title: string; count?: number }) {
 
 function lobbyPhaseBadge(lobby: Lobby) {
   const phase = lobby.phase;
+  const phaseName = lobby.currentPhase?.name;
 
   switch (phase) {
     case 'running':
@@ -290,10 +270,12 @@ function lobbyPhaseBadge(lobby: Lobby) {
 function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
   const playerCount = lobby.playerCount ?? 0;
   const gameType = lobby.gameType ?? 'capture-the-lobster';
-  const teamSize = lobby.teamSize;
-  const capacity = teamSize != null
-    ? (gameType === 'oathbreaker' ? teamSize : teamSize * 2)
-    : undefined;
+  const manifest = getGameManifest(gameType);
+  const phaseView = lobby.currentPhase?.view;
+
+  // Extract team count from team-formation phase view if available
+  const teams: any[] = phaseView?.teams ?? [];
+  const teamCount = teams.length;
 
   return (
     <button onClick={onClick} className="group cursor-pointer w-full rounded-xl parchment-strong p-5 text-left transition-all duration-200 hover:shadow-md">
@@ -302,15 +284,19 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
         {lobbyPhaseBadge(lobby)}
       </div>
       <div className="mb-2 text-sm" style={{ color: 'var(--color-ink-light)' }}>
-        <span className="font-semibold" style={{ color: 'var(--color-amber)' }}>{playerCount}</span>
-        {capacity != null ? <span>/{capacity}</span> : null} players
-        {teamSize != null && gameType !== 'oathbreaker' && (
-          <span className="ml-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>· {teamSize}v{teamSize}</span>
-        )}
+        <span className="font-semibold" style={{ color: 'var(--color-amber)' }}>{playerCount}</span> players
+        {teamCount > 0 && <span className="ml-2 text-xs" style={{ color: 'var(--color-ink-faint)' }}>· {teamCount} teams</span>}
       </div>
-      <div className="flex items-center justify-end">
-        {gameType === 'oathbreaker' && (
-          <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>OATHBREAKER</span>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-wrap gap-1">
+          {lobby.agents.slice(0, 8).map((agent: any) => (
+            <span key={agent.id} className="inline-block rounded-md px-1.5 py-0.5 text-xs font-mono" style={{ background: 'rgba(42, 31, 14, 0.06)', color: 'var(--color-ink-faint)' }}>
+              {agent.handle || agent.id}
+            </span>
+          ))}
+        </div>
+        {manifest && (
+          <span className="font-heading text-xs font-medium" style={{ color: manifest.accentColor }}>{manifest.displayName}</span>
         )}
       </div>
     </button>
@@ -318,6 +304,7 @@ function LobbyCard({ lobby, onClick }: { lobby: Lobby; onClick: () => void }) {
 }
 
 function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
+  const manifest = getGameManifest(game.gameType ?? 'capture-the-lobster');
   // OATHBREAKER game card
   if (game.gameType === 'oathbreaker') {
     const round = game.round ?? game.turn ?? 0;
@@ -351,8 +338,8 @@ function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
           </div>
         </div>
         <div className="flex items-center justify-between text-sm">
-          <span className="font-heading text-xs font-medium" style={{ color: 'var(--color-blood)' }}>
-            OATHBREAKER
+          <span className="font-heading text-xs font-medium" style={{ color: manifest?.accentColor ?? 'var(--color-blood)' }}>
+            {manifest?.displayName ?? 'OATHBREAKER'}
           </span>
           <span className="font-mono text-xs" style={{ color: 'var(--color-ink-faint)' }}>
             {game.playerCount ?? '?'} players

--- a/packages/web/src/pages/LobbyPage.tsx
+++ b/packages/web/src/pages/LobbyPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { API_BASE, getWsUrl } from '../config.js';
-import { PlayerList, ChatPanel, AutoScrollChat, TimerBar, JoinInstructions, TeamPanel } from '../components/lobby';
+import { PlayerList, ChatPanel, TimerBar, JoinInstructions, TeamPanel } from '../components/lobby';
+import { getGameDisplayName } from '../games/manifest';
 
 // ---------------------------------------------------------------------------
 // Shared types — matches the new generic LobbyDO state shape
@@ -227,8 +228,8 @@ export default function LobbyPage() {
   if (!state) return null;
 
   // Derive display info from the new state shape
-  const gameType = state.gameType ?? 'capture-the-lobster';
-  const gameLabel = gameType === 'oathbreaker' ? 'OATHBREAKER' : 'Capture the Lobster';
+  const gameType = state.gameType;
+  const gameLabel = getGameDisplayName(gameType);
   const phaseId = state.currentPhase?.id;
   const phaseView = state.currentPhase?.view;
   const chatMessages = extractChatMessages(state.relay ?? []);
@@ -236,7 +237,6 @@ export default function LobbyPage() {
   // Determine if this is a team-based or simple lobby from phase view data
   const isTeamPhase = phaseId === 'team-formation';
   const isClassSelection = phaseId === 'class-selection';
-  const isOpenQueue = phaseId === 'open-queue';
   const showTimer = state.phase === 'running' && state.deadlineMs != null;
 
   // Team formation view: { teams: [{id, members, invites}], unassigned, teamSize, numTeams }
@@ -248,9 +248,7 @@ export default function LobbyPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h1 className="font-heading text-xl font-bold" style={{ color: 'var(--color-ink)' }}>Lobby</h1>
-          {gameType !== 'capture-the-lobster' && (
-            <span className="font-heading text-sm font-medium" style={{ color: 'var(--color-blood)' }}>{gameLabel}</span>
-          )}
+          <span className="font-heading text-sm font-medium" style={{ color: 'var(--color-blood)' }}>{gameLabel}</span>
           <span className="font-mono text-sm" style={{ color: 'var(--color-ink-faint)' }}>{state.lobbyId}</span>
           {phaseBadge(state.phase, phaseId)}
           <span className="text-sm" style={{ color: 'var(--color-ink-light)' }}>{state.agents.length} agents</span>
@@ -284,7 +282,7 @@ export default function LobbyPage() {
 
       {/* Running phase: Join instructions */}
       {state.phase === 'running' && (
-        <JoinInstructions lobbyId={state.lobbyId} />
+        <JoinInstructions lobbyId={state.lobbyId} gameType={gameType} />
       )}
 
       {/* Game redirect */}

--- a/packages/workers-server/package.json
+++ b/packages/workers-server/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20250407.0",
     "@coordination-games/engine": "*",
+    "@coordination-games/game-comedy-of-the-commons": "*",
     "@coordination-games/game-ctl": "*",
     "@coordination-games/game-oathbreaker": "*",
     "ajv": "^8.17.1",

--- a/packages/workers-server/src/do/GameRoomDO.ts
+++ b/packages/workers-server/src/do/GameRoomDO.ts
@@ -29,6 +29,7 @@ import type { CoordinationGame, MerkleLeafData } from '@coordination-games/engin
 import type { Env } from '../env.js';
 
 // Side-effect imports: each calls registerGame() on module load
+import '@coordination-games/game-comedy-of-the-commons';
 import '@coordination-games/game-ctl';
 import '@coordination-games/game-oathbreaker';
 
@@ -669,6 +670,7 @@ export class GameRoomDO extends DurableObject<Env> {
     // Fire-and-forget: catch all errors to prevent unhandled rejections
     (async () => {
       try {
+        await this.ensureGameRowInD1();
         await this.env.DB.prepare(
           `INSERT INTO game_summaries (game_id, progress_counter, summary_json, updated_at)
            VALUES (?1, ?2, ?3, datetime('now'))
@@ -704,6 +706,20 @@ export class GameRoomDO extends DurableObject<Env> {
       // Final catch-all to prevent unhandled rejections
       console.error(`[GameRoomDO] Unhandled error in writeSummaryToD1:`, err);
     });
+  }
+
+  /** Ensure the parent games row exists before summary writes that FK-reference it. */
+  private async ensureGameRowInD1(): Promise<void> {
+    if (!this._meta) return;
+    await this.env.DB.prepare(
+      `INSERT OR IGNORE INTO games (game_id, game_type, finished, created_at)
+       VALUES (?1, ?2, ?3, ?4)`
+    ).bind(
+      this._meta.gameId,
+      this._meta.gameType,
+      this._meta.finished ? 1 : 0,
+      this._meta.createdAt,
+    ).run();
   }
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/workers-server/src/do/LobbyDO.ts
+++ b/packages/workers-server/src/do/LobbyDO.ts
@@ -31,6 +31,7 @@ import type {
 } from '@coordination-games/engine';
 
 // Side-effect imports — register game plugins with the engine registry
+import '@coordination-games/game-comedy-of-the-commons';
 import '@coordination-games/game-ctl';
 import '@coordination-games/game-oathbreaker';
 

--- a/scripts/comedy-demo-smoke.ts
+++ b/scripts/comedy-demo-smoke.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env tsx
+
+import { Wallet } from 'ethers';
+import { api, authenticate } from './lib/bot-agent.js';
+
+interface SmokeOptions {
+  server: string;
+  playerCount: number;
+  namePrefix: string;
+  maxWaitMs: number;
+}
+
+function parseArgs(): SmokeOptions {
+  const args = process.argv.slice(2);
+  const get = (flag: string) => {
+    const index = args.indexOf(flag);
+    return index >= 0 ? args[index + 1] : undefined;
+  };
+
+  return {
+    server: get('--server-url') ?? process.env.GAME_SERVER ?? 'http://localhost:8787',
+    playerCount: Number(get('--count') ?? process.env.BOT_COUNT ?? '4'),
+    namePrefix: get('--name-prefix') ?? 'Smoke',
+    maxWaitMs: Number(get('--max-wait-ms') ?? '10000'),
+  };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForReplay(server: string, gameId: string, maxWaitMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < maxWaitMs) {
+    try {
+      const replay = await api(server, `/api/games/${gameId}/replay`);
+      if (Array.isArray(replay.snapshots) && replay.snapshots.length > 0) {
+        return replay;
+      }
+    } catch {
+      // wait and retry
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for replay for game ${gameId}`);
+}
+
+async function main() {
+  const { server, playerCount, namePrefix, maxWaitMs } = parseArgs();
+  if (playerCount < 4) {
+    throw new Error('Comedy demo smoke requires at least 4 players');
+  }
+
+  console.log(`\ncomedy-demo-smoke — ${playerCount} players on ${server}\n`);
+
+  const players: Array<{ name: string; token: string; playerId: string; address: string }> = [];
+
+  for (let i = 0; i < playerCount; i++) {
+    const wallet = Wallet.createRandom();
+    const name = `${namePrefix}${i + 1}`;
+    const auth = await authenticate(server, wallet.privateKey, name);
+    players.push({ ...auth, name, address: wallet.address });
+    console.log(`  authenticated ${name} (${auth.playerId.slice(0, 8)}...)`);
+  }
+
+  const created = await api(server, '/api/lobbies/create', {
+    method: 'POST',
+    token: players[0].token,
+    body: { gameType: 'comedy-of-the-commons', teamSize: playerCount },
+  });
+  const lobbyId = created.lobbyId as string;
+  console.log(`\n  lobby: ${lobbyId}`);
+
+  let gameId: string | null = null;
+  for (const player of players) {
+    const joined = await api(server, '/api/player/lobby/join', {
+      method: 'POST',
+      token: player.token,
+      body: { lobbyId },
+    });
+    console.log(`  ${player.name} joined (phase: ${joined.phase ?? joined.currentPhase?.id ?? 'unknown'})`);
+    if (joined.gameId) gameId = joined.gameId;
+  }
+
+  if (!gameId) {
+    throw new Error('Lobby did not promote into a game');
+  }
+
+  const games = await api(server, '/api/games');
+  const game = Array.isArray(games) ? games.find((entry) => entry.id === gameId) : null;
+  const spectator = await api(server, `/api/games/${gameId}/spectator`);
+  const replay = await waitForReplay(server, gameId, maxWaitMs);
+  const replayUrl = `http://127.0.0.1:4177/replay/${gameId}`;
+
+  console.log('\nSmoke summary');
+  console.log(JSON.stringify({
+    lobbyId,
+    gameId,
+    playerCount,
+    gameSummary: game,
+    spectatorType: spectator.type,
+    replaySnapshots: replay.snapshots?.length ?? 0,
+    replayUrl,
+  }, null, 2));
+}
+
+main().catch((err) => {
+  console.error('\nFatal comedy-demo-smoke error:\n', err);
+  process.exit(1);
+});

--- a/scripts/comedy-demo-smoke.ts
+++ b/scripts/comedy-demo-smoke.ts
@@ -5,9 +5,11 @@ import { api, authenticate } from './lib/bot-agent.js';
 
 interface SmokeOptions {
   server: string;
+  webBaseUrl: string;
   playerCount: number;
   namePrefix: string;
   maxWaitMs: number;
+  resumeDelayMs: number;
 }
 
 function parseArgs(): SmokeOptions {
@@ -19,14 +21,33 @@ function parseArgs(): SmokeOptions {
 
   return {
     server: get('--server-url') ?? process.env.GAME_SERVER ?? 'http://localhost:8787',
+    webBaseUrl: get('--web-base-url') ?? process.env.WEB_BASE_URL ?? 'http://127.0.0.1:4173',
     playerCount: Number(get('--count') ?? process.env.BOT_COUNT ?? '4'),
     namePrefix: get('--name-prefix') ?? 'Smoke',
     maxWaitMs: Number(get('--max-wait-ms') ?? '10000'),
+    resumeDelayMs: Number(get('--resume-delay-ms') ?? '1500'),
   };
 }
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function authenticateWithRetry(server: string, privateKey: string, name: string, attempts = 4) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await authenticate(server, privateKey, name);
+    } catch (error) {
+      lastError = error;
+      const message = String(error instanceof Error ? error.message : error);
+      if (!/worker restarted mid-request|503/i.test(message) || attempt === attempts - 1) {
+        throw error;
+      }
+      await sleep(500 * (attempt + 1));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 async function waitForReplay(server: string, gameId: string, maxWaitMs: number) {
@@ -45,20 +66,38 @@ async function waitForReplay(server: string, gameId: string, maxWaitMs: number) 
   throw new Error(`Timed out waiting for replay for game ${gameId}`);
 }
 
+async function waitForFramework(server: string, maxWaitMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < maxWaitMs) {
+    try {
+      const framework = await api(server, '/api/framework');
+      if (framework?.status === 'active') {
+        return framework;
+      }
+    } catch {
+      // wait and retry
+    }
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for framework readiness at ${server}`);
+}
+
 async function main() {
-  const { server, playerCount, namePrefix, maxWaitMs } = parseArgs();
+  const { server, webBaseUrl, playerCount, namePrefix, maxWaitMs, resumeDelayMs } = parseArgs();
   if (playerCount < 4) {
     throw new Error('Comedy demo smoke requires at least 4 players');
   }
 
   console.log(`\ncomedy-demo-smoke — ${playerCount} players on ${server}\n`);
 
+  await waitForFramework(server, maxWaitMs);
+
   const players: Array<{ name: string; token: string; playerId: string; address: string }> = [];
 
   for (let i = 0; i < playerCount; i++) {
     const wallet = Wallet.createRandom();
     const name = `${namePrefix}${i + 1}`;
-    const auth = await authenticate(server, wallet.privateKey, name);
+    const auth = await authenticateWithRetry(server, wallet.privateKey, name);
     players.push({ ...auth, name, address: wallet.address });
     console.log(`  authenticated ${name} (${auth.playerId.slice(0, 8)}...)`);
   }
@@ -90,7 +129,20 @@ async function main() {
   const game = Array.isArray(games) ? games.find((entry) => entry.id === gameId) : null;
   const spectator = await api(server, `/api/games/${gameId}/spectator`);
   const replay = await waitForReplay(server, gameId, maxWaitMs);
-  const replayUrl = `http://127.0.0.1:4177/replay/${gameId}`;
+
+  await sleep(resumeDelayMs);
+
+  const resumedSpectator = await api(server, `/api/games/${gameId}/spectator`);
+  const resumedReplay = await waitForReplay(server, gameId, maxWaitMs);
+  const initialProgress = spectator.progressCounter ?? 0;
+  const resumedProgress = resumedSpectator.progressCounter ?? 0;
+  if (resumedProgress < initialProgress) {
+    throw new Error(`Replay/resume regressed progress counter from ${initialProgress} to ${resumedProgress}`);
+  }
+  if ((resumedReplay.snapshots?.length ?? 0) < (replay.snapshots?.length ?? 0)) {
+    throw new Error('Replay/resume reduced snapshot count after reconnect check');
+  }
+  const replayUrl = `${webBaseUrl}/replay/${gameId}`;
 
   console.log('\nSmoke summary');
   console.log(JSON.stringify({
@@ -100,6 +152,10 @@ async function main() {
     gameSummary: game,
     spectatorType: spectator.type,
     replaySnapshots: replay.snapshots?.length ?? 0,
+    resumedSpectatorType: resumedSpectator.type,
+    resumedReplaySnapshots: resumedReplay.snapshots?.length ?? 0,
+    initialProgress,
+    resumedProgress,
     replayUrl,
   }, null, 2));
 }

--- a/scripts/comedy-demo-smoke.ts
+++ b/scripts/comedy-demo-smoke.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 
 import { Wallet } from 'ethers';
+import { promises as fs } from 'fs';
 import { api, authenticate } from './lib/bot-agent.js';
 
 interface SmokeOptions {
@@ -10,6 +11,9 @@ interface SmokeOptions {
   namePrefix: string;
   maxWaitMs: number;
   resumeDelayMs: number;
+  finishWaitMs: number;
+  workerLogPath?: string;
+  directGameCreate: boolean;
 }
 
 function parseArgs(): SmokeOptions {
@@ -26,6 +30,9 @@ function parseArgs(): SmokeOptions {
     namePrefix: get('--name-prefix') ?? 'Smoke',
     maxWaitMs: Number(get('--max-wait-ms') ?? '10000'),
     resumeDelayMs: Number(get('--resume-delay-ms') ?? '1500'),
+    finishWaitMs: Number(get('--finish-wait-ms') ?? '0'),
+    workerLogPath: get('--worker-log-path') ?? process.env.WORKER_LOG_PATH,
+    directGameCreate: (get('--direct-game-create') ?? process.env.DIRECT_GAME_CREATE ?? '').toLowerCase() === 'true',
   };
 }
 
@@ -33,14 +40,20 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function authenticateWithRetry(server: string, privateKey: string, name: string, attempts = 4) {
+async function authenticateWithRetry(server: string, privateKey: string, baseName: string, attempts = 4) {
   let lastError: unknown;
+  let currentName = baseName;
   for (let attempt = 0; attempt < attempts; attempt++) {
     try {
-      return await authenticate(server, privateKey, name);
+      const auth = await authenticate(server, privateKey, currentName);
+      return { ...auth, name: currentName };
     } catch (error) {
       lastError = error;
       const message = String(error instanceof Error ? error.message : error);
+      if (/already taken|409/i.test(message)) {
+        currentName = `${baseName}-${Date.now().toString(36).slice(-4)}-${attempt + 1}`;
+        continue;
+      }
       if (!/worker restarted mid-request|503/i.test(message) || attempt === attempts - 1) {
         throw error;
       }
@@ -66,6 +79,41 @@ async function waitForReplay(server: string, gameId: string, maxWaitMs: number) 
   throw new Error(`Timed out waiting for replay for game ${gameId}`);
 }
 
+async function waitForGameFinished(server: string, gameId: string, maxWaitMs: number) {
+  const started = Date.now();
+  while (Date.now() - started < maxWaitMs) {
+    try {
+      const game = await api(server, `/api/games/${gameId}`);
+      if (game?.finished || game?.phase === 'finished') {
+        return game;
+      }
+    } catch {
+      // wait and retry
+    }
+    await sleep(1000);
+  }
+  throw new Error(`Timed out waiting for game ${gameId} to finish`);
+}
+
+async function readLogOffset(path?: string): Promise<number | null> {
+  if (!path) return null;
+  try {
+    const stat = await fs.stat(path);
+    return stat.size;
+  } catch {
+    return 0;
+  }
+}
+
+async function assertNoSettlementErrors(path: string | undefined, offset: number | null) {
+  if (!path || offset === null) return;
+  const text = await fs.readFile(path, 'utf8');
+  const tail = text.slice(offset);
+  if (/On-chain settlement failed|Buffer is not defined/i.test(tail)) {
+    throw new Error('Worker log contains settlement failure after smoke run');
+  }
+}
+
 async function waitForFramework(server: string, maxWaitMs: number) {
   const started = Date.now();
   while (Date.now() - started < maxWaitMs) {
@@ -83,7 +131,7 @@ async function waitForFramework(server: string, maxWaitMs: number) {
 }
 
 async function main() {
-  const { server, webBaseUrl, playerCount, namePrefix, maxWaitMs, resumeDelayMs } = parseArgs();
+  const { server, webBaseUrl, playerCount, namePrefix, maxWaitMs, resumeDelayMs, finishWaitMs, workerLogPath, directGameCreate } = parseArgs();
   if (playerCount < 4) {
     throw new Error('Comedy demo smoke requires at least 4 players');
   }
@@ -91,6 +139,7 @@ async function main() {
   console.log(`\ncomedy-demo-smoke — ${playerCount} players on ${server}\n`);
 
   await waitForFramework(server, maxWaitMs);
+  const workerLogOffset = await readLogOffset(workerLogPath);
 
   const players: Array<{ name: string; token: string; playerId: string; address: string }> = [];
 
@@ -98,31 +147,53 @@ async function main() {
     const wallet = Wallet.createRandom();
     const name = `${namePrefix}${i + 1}`;
     const auth = await authenticateWithRetry(server, wallet.privateKey, name);
-    players.push({ ...auth, name, address: wallet.address });
-    console.log(`  authenticated ${name} (${auth.playerId.slice(0, 8)}...)`);
+    players.push({ ...auth, address: wallet.address });
+    console.log(`  authenticated ${auth.name} (${auth.playerId.slice(0, 8)}...)`);
   }
 
-  const created = await api(server, '/api/lobbies/create', {
-    method: 'POST',
-    token: players[0].token,
-    body: { gameType: 'comedy-of-the-commons', teamSize: playerCount },
-  });
-  const lobbyId = created.lobbyId as string;
-  console.log(`\n  lobby: ${lobbyId}`);
-
+  let lobbyId: string | null = null;
   let gameId: string | null = null;
-  for (const player of players) {
-    const joined = await api(server, '/api/player/lobby/join', {
+
+  if (directGameCreate) {
+    const created = await api(server, '/api/games/create', {
       method: 'POST',
-      token: player.token,
-      body: { lobbyId },
+      body: {
+        gameType: 'comedy-of-the-commons',
+        config: {
+          seed: `smoke-${Date.now().toString(36)}`,
+          playerIds: players.map((player) => player.playerId),
+          maxRounds: 1,
+          turnTimerSeconds: 1,
+        },
+        playerIds: players.map((player) => player.playerId),
+        handleMap: Object.fromEntries(players.map((player) => [player.playerId, player.name])),
+        teamMap: Object.fromEntries(players.map((player) => [player.playerId, 'FFA'])),
+      },
     });
-    console.log(`  ${player.name} joined (phase: ${joined.phase ?? joined.currentPhase?.id ?? 'unknown'})`);
-    if (joined.gameId) gameId = joined.gameId;
+    gameId = created.gameId as string;
+    console.log(`\n  direct game: ${gameId}`);
+  } else {
+    const created = await api(server, '/api/lobbies/create', {
+      method: 'POST',
+      token: players[0].token,
+      body: { gameType: 'comedy-of-the-commons', teamSize: playerCount },
+    });
+    lobbyId = created.lobbyId as string;
+    console.log(`\n  lobby: ${lobbyId}`);
+
+    for (const player of players) {
+      const joined = await api(server, '/api/player/lobby/join', {
+        method: 'POST',
+        token: player.token,
+        body: { lobbyId },
+      });
+      console.log(`  ${player.name} joined (phase: ${joined.phase ?? joined.currentPhase?.id ?? 'unknown'})`);
+      if (joined.gameId) gameId = joined.gameId;
+    }
   }
 
   if (!gameId) {
-    throw new Error('Lobby did not promote into a game');
+    throw new Error('Flow did not produce a game');
   }
 
   const games = await api(server, '/api/games');
@@ -142,6 +213,16 @@ async function main() {
   if ((resumedReplay.snapshots?.length ?? 0) < (replay.snapshots?.length ?? 0)) {
     throw new Error('Replay/resume reduced snapshot count after reconnect check');
   }
+
+  let finishedGame: any = null;
+  let finishedReplaySnapshots: number | null = null;
+  if (finishWaitMs > 0) {
+    finishedGame = await waitForGameFinished(server, gameId, finishWaitMs);
+    const finishedReplay = await waitForReplay(server, gameId, maxWaitMs);
+    finishedReplaySnapshots = finishedReplay.snapshots?.length ?? 0;
+    await assertNoSettlementErrors(workerLogPath, workerLogOffset);
+  }
+
   const replayUrl = `${webBaseUrl}/replay/${gameId}`;
 
   console.log('\nSmoke summary');
@@ -149,6 +230,7 @@ async function main() {
     lobbyId,
     gameId,
     playerCount,
+    creationMode: directGameCreate ? 'direct-game' : 'lobby-join',
     gameSummary: game,
     spectatorType: spectator.type,
     replaySnapshots: replay.snapshots?.length ?? 0,
@@ -156,6 +238,9 @@ async function main() {
     resumedReplaySnapshots: resumedReplay.snapshots?.length ?? 0,
     initialProgress,
     resumedProgress,
+    finished: finishedGame ? (finishedGame.finished ?? finishedGame.phase === 'finished') : false,
+    finishedProgressCounter: finishedGame?.progressCounter ?? null,
+    finishedReplaySnapshots,
     replayUrl,
   }, null, 2));
 }


### PR DESCRIPTION
## Summary
- extend the latest Comedy demo smoke so it can verify a game through full completion
- add worker-log settlement checks to catch runtime regressions like Buffer/settlement failures
- add an optional fast direct-game mode to keep the smoke practical for local runtime confidence\n\n## Validation
- clean-start smoke now proves: auth → game creation → spectator/replay → replay/resume → finished state → settled on-chain
- latest successful run produced replay URL:
  - \\n\n## Notes
- this is a latest-main runtime confidence slice, not new product surface
- the direct-game mode exists so the smoke can finish quickly without waiting through a long lobby-based path