### PR TITLE
fix(workers): auto-start direct-created games

### DIFF
--- a/packages/workers-server/src/index.ts
+++ b/packages/workers-server/src/index.ts
@@ -566,6 +566,16 @@ async function handleCreateGame(request: Request, env: Env): Promise<Response> {
     )),
   ]);
 
+  const startResp = await doStub.fetch(new Request('https://do/action', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ playerId: null, action: { type: 'game_start' } }),
+  }));
+  if (!startResp.ok) {
+    const err = await startResp.json() as any;
+    return Response.json({ error: err.error ?? 'Game start failed' }, { status: startResp.status });
+  }
+
   console.log(`[Worker] Created ${gameType} game ${gameId} for ${playerIds.length} players`);
   return Response.json({ gameId, gameType, playerCount: playerIds.length }, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- send the initial \ system action after \ creates a direct game
- align the direct-create path with the existing lobby-created game start behavior
- unblock fast full-completion Comedy smoke runs that use direct game creation\n\n## Validation
- verified on the rebuilt \ lane that a direct-created Comedy game now advances from \ to \, reaches \, and settles on-chain cleanly
- confirmed replay snapshots progress from waiting → playing → finished\n\n## Notes
- this is a narrow worker/runtime fix for the direct-create path only
- lobby-created games already had the correct auto-start behavior via \