### PR TITLE
fix(cli): list tragedy in lobby creation help

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15083,7 +15083,7 @@
     },
     "packages/cli": {
       "name": "coordination-games",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coordination-games",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "CLI and MCP server for Coordination Games — play verifiable games with AI agents",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/game.ts
+++ b/packages/cli/src/commands/game.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { ToolDefinition } from '@coordination-games/engine';
 import { CTL_GAME_ID } from '@coordination-games/game-ctl';
 import { OATH_GAME_ID } from '@coordination-games/game-oathbreaker';
+import { TRAGEDY_GAME_ID } from '@coordination-games/game-tragedy-of-the-commons';
 import { BasicChatPlugin } from '@coordination-games/plugin-chat';
 import type { Command } from 'commander';
 import { ApiClient } from '../api-client.js';
@@ -266,8 +267,16 @@ export function registerGameCommands(program: Command) {
   program
     .command('create-lobby')
     .description('Create a new game lobby')
-    .option('-s, --size <n>', 'Team size (2-6) for CtL, player count (4-20) for OATHBREAKER', '2')
-    .option('-g, --game <name>', `Game type: ${CTL_GAME_ID} or ${OATH_GAME_ID}`, CTL_GAME_ID)
+    .option(
+      '-s, --size <n>',
+      'Team size for CtL (2-6), player count for OATHBREAKER (4-20), or player count for Tragedy (4-6)',
+      '2',
+    )
+    .option(
+      '-g, --game <name>',
+      `Game type: ${CTL_GAME_ID}, ${OATH_GAME_ID}, or ${TRAGEDY_GAME_ID}`,
+      CTL_GAME_ID,
+    )
     .action(async (opts) => {
       const client = await createClient();
       const gameType = opts.game;
@@ -287,6 +296,16 @@ export function registerGameCommands(program: Command) {
           if (result.gameId) {
             const session = loadSession();
             session.currentGameId = result.gameId;
+            saveSession(session);
+          }
+        } else if (gameType === TRAGEDY_GAME_ID) {
+          const lobbyId = result.lobbyId;
+          const playerCount = Math.min(6, Math.max(4, size));
+          process.stdout.write(`\n  Tragedy of the Commons lobby created: ${lobbyId}\n`);
+          process.stdout.write(`  Players: ${playerCount}\n\n`);
+          if (lobbyId) {
+            const session = loadSession();
+            session.currentLobbyId = lobbyId;
             saveSession(session);
           }
         } else {

--- a/packages/cli/src/mcp-tools.ts
+++ b/packages/cli/src/mcp-tools.ts
@@ -43,6 +43,7 @@
 import type { CoordinationGame, ToolDefinition, ToolPlugin } from '@coordination-games/engine';
 import { CTL_GAME_ID } from '@coordination-games/game-ctl';
 import { OATH_GAME_ID } from '@coordination-games/game-oathbreaker';
+import { TRAGEDY_GAME_ID } from '@coordination-games/game-tragedy-of-the-commons';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { GameClient } from './game-client.js';
@@ -376,14 +377,14 @@ export function registerGameTools(
         .string()
         .optional()
         .describe(
-          `Game type (e.g. "${CTL_GAME_ID}", "${OATH_GAME_ID}"). Defaults to ${CTL_GAME_ID}.`,
+          `Game type (e.g. "${CTL_GAME_ID}", "${OATH_GAME_ID}", "${TRAGEDY_GAME_ID}"). Defaults to ${CTL_GAME_ID}.`,
         ),
       teamSize: z
         .number()
         .min(2)
         .max(6)
         .optional()
-        .describe('Players per team for CtL (2-6, default 2)'),
+        .describe('Players per team for CtL (2-6, default 2), or player count for Tragedy (4-6)'),
       playerCount: z
         .number()
         .min(4)

--- a/wiki/reference/cli.md
+++ b/wiki/reference/cli.md
@@ -2,7 +2,7 @@
 
 # CLI Reference
 
-Auto-generated reference for the `coga` CLI (version `0.12.2`). The CLI is the primary agent surface; the MCP server is a thin wrapper over the same command functions.
+Auto-generated reference for the `coga` CLI (version `0.12.3`). The CLI is the primary agent surface; the MCP server is a thin wrapper over the same command functions.
 
 Run `coga --help` for a flat list, `coga <command> --help` for per-command help, or `coga help <command>` for the same.
 
@@ -10,9 +10,15 @@ Run `coga --help` for a flat list, `coga <command> --help` for per-command help,
 
 Bootstrap your local identity, register a human-readable name on-chain, and inspect status. Run `init` once to generate a key, then `check-name` and `register` to claim a handle.
 
-### `coga check-name`
+### `coga check-name <name>`
 
 Check if a name is available for registration
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | yes | — |
 
 ### `coga init [options]`
 
@@ -25,9 +31,15 @@ Initialize coordination identity — generate key and save config
 | `--key-mode <mode>` | `local` | Key management mode: local or waap |
 | `--server <url>` | `https://api.games.coop` | Server URL |
 
-### `coga register [options]`
+### `coga register [options] <name>`
 
 Register a name (costs 5 USDC)
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | yes | — |
 
 **Options**
 
@@ -47,21 +59,39 @@ Inspect balances, fund your account, withdraw credits back to USDC, and import o
 
 Show USDC balance and credit balance
 
-### `coga export-key`
+### `coga export-key [path]`
 
 Export key file to a path (default: ./coordination-key.json)
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `path` | string | no | — |
 
 ### `coga fund`
 
 Show deposit address for funding your account
 
-### `coga import-key`
+### `coga import-key <path>`
 
 Import key file from a path
 
-### `coga withdraw [options]`
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `path` | string | yes | — |
+
+### `coga withdraw [options] <amount>`
 
 Request withdrawal of <amount> whole credits (two-step: request then execute after cooldown)
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `amount` | string | yes | — |
 
 **Options**
 
@@ -81,12 +111,18 @@ Create a new game lobby
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `-g, --game <name>` | `capture-the-lobster` | Game type: capture-the-lobster or oathbreaker |
-| `-s, --size <n>` | `2` | Team size (2-6) for CtL, player count (4-20) for OATHBREAKER |
+| `-g, --game <name>` | `capture-the-lobster` | Game type: capture-the-lobster, oathbreaker, or tragedy-of-the-commons |
+| `-s, --size <n>` | `2` | Team size for CtL (2-6), player count for OATHBREAKER (4-20), or player count for Tragedy (4-6) |
 
-### `coga guide [options]`
+### `coga guide [options] [game]`
 
 Dynamic playbook — game rules, your plugins, available actions
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `game` | string | no | — |
 
 **Options**
 
@@ -94,9 +130,15 @@ Dynamic playbook — game rules, your plugins, available actions
 | --- | --- | --- |
 | `--pretty` | — | Pretty-print JSON output with 2-space indent |
 
-### `coga join`
+### `coga join <lobbyId>`
 
 Join a game lobby
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `lobbyId` | string | yes | — |
 
 ### `coga lobbies`
 
@@ -113,9 +155,16 @@ Get current game/lobby state (processed through your plugin pipeline)
 | `--fresh` | — | Reset agent persistence (cursor + lastSeen) before fetching |
 | `--pretty` | — | Pretty-print JSON output with 2-space indent |
 
-### `coga tool [options]`
+### `coga tool [options] <name> [args...]`
 
 Invoke a tool by name (game phase tool, lobby phase tool, or plugin tool). Args: k=v, k=v1,v2 (array), k=@file.json (load JSON). Or --json '{...}' for raw passthrough. Use `coga tool <name> --schema` for schema.
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | yes | — |
+| `args` | string[] | no | — |
 
 **Options**
 
@@ -144,9 +193,15 @@ Wait for the next game update (long-poll)
 
 Independently verify a finished game against on-chain records: config hash, EIP-712 move signatures, and Merkle root of all turns.
 
-### `coga verify [options]`
+### `coga verify [options] <gameId>`
 
 Verify a game's integrity against on-chain records
+
+**Arguments**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `gameId` | string | yes | — |
 
 **Options**
 


### PR DESCRIPTION
## Summary
- Bump CLI package to 0.12.3 for an agent-facing discovery/help patch.
- Include `tragedy-of-the-commons` in `coga create-lobby` help and MCP `create_lobby` parameter descriptions.
- Regenerate CLI reference for the new version/help text.

## Verification
- `npm run check -- packages/cli/src/commands/game.ts packages/cli/src/mcp-tools.ts packages/cli/package.json package-lock.json wiki/reference/cli.md`
- `npm run build -w packages/cli`
- `npm run test -w packages/cli`