### PR TITLE
fix(tragedy): default lobbies to four players

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15083,7 +15083,7 @@
     },
     "packages/cli": {
       "name": "coordination-games",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coordination-games",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "CLI and MCP server for Coordination Games — play verifiable games with AI agents",
   "type": "module",
   "bin": {

--- a/packages/cli/src/game-client.ts
+++ b/packages/cli/src/game-client.ts
@@ -11,6 +11,7 @@
  */
 
 import { OATH_GAME_ID } from '@coordination-games/game-oathbreaker';
+import { TRAGEDY_GAME_ID } from '@coordination-games/game-tragedy-of-the-commons';
 import { ethers } from 'ethers';
 import * as agentPersistence from './agent-persistence.js';
 import { AgentStateDiffer } from './agent-state-differ.js';
@@ -419,6 +420,10 @@ export class GameClient {
       // For OATHBREAKER, teamSize is the total player count to auto-start (4-20)
       const teamSize = Math.min(20, Math.max(4, size || 4));
       result = await this.api.createLobby(gameType ? { gameType, teamSize } : { teamSize });
+    } else if (gameType === TRAGEDY_GAME_ID) {
+      // For Tragedy, teamSize carries the FFA player-count target (4-6).
+      const teamSize = Math.min(6, Math.max(4, size || 4));
+      result = await this.api.createLobby({ gameType, teamSize });
     } else {
       const teamSize = Math.min(6, Math.max(2, size || 2));
       result = await this.api.createLobby(gameType ? { gameType, teamSize } : { teamSize });

--- a/packages/cli/src/mcp-tools.ts
+++ b/packages/cli/src/mcp-tools.ts
@@ -384,7 +384,9 @@ export function registerGameTools(
         .min(2)
         .max(6)
         .optional()
-        .describe('Players per team for CtL (2-6, default 2), or player count for Tragedy (4-6)'),
+        .describe(
+          'Players per team for CtL (2-6, default 2), or player count for Tragedy (4-6, default 4)',
+        ),
       playerCount: z
         .number()
         .min(4)
@@ -395,7 +397,8 @@ export function registerGameTools(
     async ({ gameType, teamSize, playerCount }) => {
       try {
         const game = gameType || CTL_GAME_ID;
-        const size = game === OATH_GAME_ID ? playerCount || 4 : teamSize || 2;
+        const size =
+          game === OATH_GAME_ID || game === TRAGEDY_GAME_ID ? playerCount || 4 : teamSize || 2;
         const result = await client.createLobby(game, size);
         return jsonResult(result);
       } catch (err) {

--- a/packages/web/src/games/tragedy-of-the-commons/webPlugin.tsx
+++ b/packages/web/src/games/tragedy-of-the-commons/webPlugin.tsx
@@ -43,7 +43,7 @@ function TragedyLobbyCard({
   onClick?: (() => void) | undefined;
 }) {
   const playerCount = lobby.playerCount ?? 0;
-  const capacity = lobby.teamSize ?? undefined;
+  const capacity = Math.min(6, Math.max(4, lobby.teamSize ?? 4));
   return (
     <button
       type="button"

--- a/wiki/reference/cli.md
+++ b/wiki/reference/cli.md
@@ -2,7 +2,7 @@
 
 # CLI Reference
 
-Auto-generated reference for the `coga` CLI (version `0.12.3`). The CLI is the primary agent surface; the MCP server is a thin wrapper over the same command functions.
+Auto-generated reference for the `coga` CLI (version `0.12.4`). The CLI is the primary agent surface; the MCP server is a thin wrapper over the same command functions.
 
 Run `coga --help` for a flat list, `coga <command> --help` for per-command help, or `coga help <command>` for the same.
 


### PR DESCRIPTION
## Summary
- Bump CLI to 0.12.4 for a Tragedy lobby creation fix.
- Default Tragedy CLI/MCP lobby creation to 4 players instead of CtL's 2-player default.
- Render Tragedy lobby cards with 4-6 player capacity semantics so existing 2-valued rows display as `1/4`, not `1/2`.

## Verification
- `npm run check -- packages/web/src/games/tragedy-of-the-commons/webPlugin.tsx packages/cli/src/game-client.ts packages/cli/src/mcp-tools.ts packages/cli/package.json package-lock.json wiki/reference/cli.md`
- `npm run build -w packages/cli`
- `npm run test -w packages/cli`
- `npm run test -w packages/web`
- `npm run build -w packages/web`