### PR TITLE
Collapse the harness to one spec format (drop bare single-spec)

### DIFF
--- a/packages/model-harness/src/index.ts
+++ b/packages/model-harness/src/index.ts
@@ -18,7 +18,7 @@
 import { promises as fsp } from 'node:fs';
 import path from 'node:path';
 import { analyzeRun } from './analyze.js';
-import { resolvePersonaDir, runBatch } from './orchestrate.js';
+import { runBatch } from './orchestrate.js';
 import { expandSeatPlan, loadCampaign } from './spec.js';
 import type { CampaignRun, RunSpec } from './types.js';
 
@@ -68,111 +68,20 @@ Notes:
 `;
 
 // ---------------------------------------------------------------------------
-// Dry-run: resolve and print the seat plan, no side effects.
-// ---------------------------------------------------------------------------
-
-function printSeatPlan(spec: RunSpec): void {
-  const plans = expandSeatPlan(spec);
-
-  const totalSeats = plans.length;
-  const backendCounts = plans.reduce<Record<string, number>>((acc, p) => {
-    acc[p.backend] = (acc[p.backend] ?? 0) + 1;
-    return acc;
-  }, {});
-
-  console.log('\n=== Resolved seat plan (dry run) ===\n');
-  console.log(`game:       ${spec.game}`);
-  console.log(`rounds:     ${spec.rounds}`);
-  console.log(`server:     ${spec.server}`);
-  console.log(`identities: ${spec.identities}`);
-  console.log(`output:     ${spec.output}`);
-  console.log(`params:     ${JSON.stringify(spec.params)}`);
-  console.log(
-    `limits:     maxModelCallsPerBot=${spec.limits.maxModelCallsPerBot}, ` +
-      `wallClockMsPerRun=${spec.limits.wallClockMsPerRun}`,
-  );
-  if (spec.analysis) {
-    console.log(
-      `analysis:   enabled=${spec.analysis.enabled}, model=${spec.analysis.model}` +
-        (spec.analysis.lenses ? `, lenses=[${spec.analysis.lenses.join(', ')}]` : ''),
-    );
-  } else {
-    console.log('analysis:   (none)');
-  }
-
-  console.log(
-    `\nseats:      ${totalSeats} total — ` +
-      Object.entries(backendCounts)
-        .map(([b, n]) => `${n} ${b}`)
-        .join(', '),
-  );
-  console.log('');
-
-  const seatRows = plans.map((p) => {
-    const dir = resolvePersonaDir(p.persona);
-    return {
-      seat: p.seatIndex,
-      persona: p.persona,
-      personaDir: dir,
-      model: p.model,
-      backend: p.backend,
-    };
-  });
-
-  for (const row of seatRows) {
-    console.log(
-      `  seat ${String(row.seat).padStart(2)}  ` +
-        `persona=${row.persona.padEnd(26)}  ` +
-        `model=${row.model.padEnd(36)}  ` +
-        `backend=${row.backend}`,
-    );
-    console.log(`           → ${row.personaDir}`);
-  }
-  console.log('');
-}
-
-// ---------------------------------------------------------------------------
-// run
+// run — every spec is a list of runs (1 or many); always go through runCampaign.
 // ---------------------------------------------------------------------------
 
 async function cmdRun(specPath: string, dryRun: boolean): Promise<number> {
-  const { form, runs } = await loadCampaign(specPath);
-
+  const runs = await loadCampaign(specPath);
   if (dryRun) {
-    printPlan(form, runs);
+    printPlan(runs);
     return 0;
   }
-
-  // Single bare spec → unchanged one-run behavior (flat output, no campaign index).
-  if (form === 'single') {
-    const cr = runs[0];
-    if (!cr) throw new Error(`no runs resolved from ${specPath}`);
-    const { runDir, lobbyId, gameId, manifest } = await runBatch(cr.spec);
-    console.log(`\nrun complete:`);
-    console.log(`  runDir:  ${runDir}`);
-    console.log(`  lobbyId: ${lobbyId}`);
-    console.log(`  gameId:  ${gameId}`);
-    void manifest;
-    await maybeAnalyze(cr.spec, runDir);
-    return 0;
-  }
-
   return runCampaign(runs);
 }
 
-/** Run the judge over a finished run dir if the spec enables it. */
-async function maybeAnalyze(spec: RunSpec, runDir: string): Promise<void> {
-  if (!spec.analysis?.enabled) return;
-  console.log(`\n[analyze] running judge (${spec.analysis.model})...`);
-  await analyzeRun(runDir, {
-    model: spec.analysis.model,
-    ...(spec.analysis.lenses ? { lenses: spec.analysis.lenses } : {}),
-  });
-  console.log(`  analysis: ${path.join(runDir, 'analysis.json')}`);
-}
-
 // ---------------------------------------------------------------------------
-// Campaign execution (globals/games form) — sequential, failure-isolated.
+// Run execution — sequential, failure-isolated, grouped under one campaign dir.
 // ---------------------------------------------------------------------------
 
 interface CampaignRunSummary {
@@ -276,15 +185,9 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-/** Print the resolved plan for a dry run (single seat plan, or campaign grid). */
-function printPlan(form: 'single' | 'campaign', runs: CampaignRun[]): void {
-  if (form === 'single') {
-    const cr = runs[0];
-    if (cr) printSeatPlan(cr.spec);
-    return;
-  }
-
-  console.log('\n=== Campaign plan (dry run) ===\n');
+/** Print the resolved run plan for a dry run (the expanded grid + total count). */
+function printPlan(runs: CampaignRun[]): void {
+  console.log('\n=== Run plan (dry run) ===\n');
   const first = runs[0]?.spec;
   if (first) {
     console.log(`server:     ${first.server}`);

--- a/packages/model-harness/src/spec.ts
+++ b/packages/model-harness/src/spec.ts
@@ -1,8 +1,9 @@
 /**
  * Spec parser and seat expansion for the Unified Model Harness.
  *
- * loadSpec(path) → RunSpec: parses a YAML (or JSON) run-spec file, validates
- * required fields, and applies defaults.
+ * loadCampaign(path) → CampaignRun[]: parses a YAML (or JSON) spec file in the
+ * single `{ globals?, games[] }` format, validates the scope partition, applies
+ * defaults, and flattens `repeats` into one CampaignRun per run.
  *
  * expandSeatPlan(spec) → SeatPlan[]: cycles personas across seat counts and
  * resolves backend via backendForModel. Identity minting (wallet creation/pool
@@ -19,7 +20,6 @@ import {
   type Backend,
   backendForModel,
   type CampaignRun,
-  type LoadedCampaign,
   type RunLimits,
   type RunSpec,
   type SeatSpec,
@@ -41,45 +41,30 @@ const DEFAULT_SERVER = process.env.GAME_SERVER ?? 'http://localhost:8787';
 // ---------------------------------------------------------------------------
 
 /**
- * Parse a YAML or JSON run-spec file (bare single-run shape). Applies defaults
- * for optional fields. Throws with a clear message if required fields are
- * missing or invalid.
+ * Load a spec file → the list of runs it describes. ONE format:
  *
- * @param filePath - Absolute or relative path to the run-spec YAML/JSON file.
- * @returns Validated, defaulted RunSpec.
- */
-export async function loadSpec(filePath: string): Promise<RunSpec> {
-  const { obj, abs } = await readYamlObject(filePath);
-  return parseRunSpecObject(obj, abs);
-}
-
-/**
- * Load a spec file as a campaign — supports both shapes:
- *  - Bare run-spec (no `games` key)  → one run, form 'single' (legacy; unchanged).
- *  - Campaign `{ globals?, games[] }` → N runs, form 'campaign'.
+ *   globals?: { server, identities, output, limits, analysis }   # campaign-wide
+ *   games:    [ { game, rounds, params, seats, repeats?, label? }, ... ]
  *
- * Campaign scope is a STRICT PARTITION: `globals` holds campaign-wide fields,
- * each `games[]` entry holds per-game fields, and no field may appear in both.
- * A misplaced field is a hard error — that's the payoff of no-overrides: we can
- * tell you exactly where a field belongs.
+ * Scope is a STRICT PARTITION: every field lives in exactly one section, and a
+ * misplaced field is a hard error (the payoff of no-overrides — we can tell you
+ * exactly where a field belongs). A single run is just a one-entry `games` list;
+ * there is no separate flat shape.
  */
-export async function loadCampaign(filePath: string): Promise<LoadedCampaign> {
+export async function loadCampaign(filePath: string): Promise<CampaignRun[]> {
   const { obj, abs } = await readYamlObject(filePath);
 
-  // Bare run-spec → a one-run "single" campaign (run dir stays `run-<ts>`).
   if (!('games' in obj)) {
-    const spec = parseRunSpecObject(obj, abs);
-    return {
-      form: 'single',
-      runs: [{ spec, baseLabel: spec.game, repeatIndex: 1, repeatTotal: 1 }],
-    };
+    throw new Error(
+      `spec at ${abs}: missing "games". A spec is { globals?, games: [...] } — ` +
+        'a single run is just one entry in "games".',
+    );
   }
 
-  // Campaign form.
   const globals = parseGlobals(obj.globals, abs);
   const rawGames = obj.games;
   if (!Array.isArray(rawGames) || rawGames.length === 0) {
-    throw new Error(`campaign at ${abs}: "games" must be a non-empty array`);
+    throw new Error(`spec at ${abs}: "games" must be a non-empty array`);
   }
 
   const runs: CampaignRun[] = [];
@@ -87,7 +72,7 @@ export async function loadCampaign(filePath: string): Promise<LoadedCampaign> {
 
   rawGames.forEach((entry: unknown, idx: number) => {
     if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
-      throw new Error(`campaign at ${abs}: games[${idx}] must be an object`);
+      throw new Error(`spec at ${abs}: games[${idx}] must be an object`);
     }
     const g = entry as Record<string, unknown>;
     assertKeysAllowed(g, GAME_KEYS, `games[${idx}]`, abs);
@@ -110,7 +95,7 @@ export async function loadCampaign(filePath: string): Promise<LoadedCampaign> {
     }
   });
 
-  return { form: 'campaign', runs };
+  return runs;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/model-harness/src/types.ts
+++ b/packages/model-harness/src/types.ts
@@ -182,13 +182,6 @@ export interface CampaignRun {
   repeatTotal: number;
 }
 
-/** Result of loading a spec file: a bare single run, or a multi-run campaign. */
-export interface LoadedCampaign {
-  /** 'single' = a bare run-spec (legacy shape); 'campaign' = globals/games form. */
-  form: 'single' | 'campaign';
-  runs: CampaignRun[];
-}
-
 // ---------------------------------------------------------------------------
 // Resolved seat — one concrete bot the orchestrator will run.
 // ---------------------------------------------------------------------------

--- a/runs/claude-totc.yaml
+++ b/runs/claude-totc.yaml
@@ -1,23 +1,31 @@
 # Claude-only end-to-end smoke: 4 Haiku bots play Tragedy of the Commons to finish.
 # Uses bare `haiku` alias → backendForModel('haiku') = claude backend, and the
 # `claude` CLI understands `--model haiku` directly. Local ~/.claude creds; no key.
-game: tragedy-of-the-commons
-rounds: 8
-params:
-  teamSize: 4
-server: http://localhost:8787
-identities: ephemeral
-output: /home/lucian/workspace-core/capture-the-lobster/runs/out
-seats:
-  - persona: ./personas/peaceful-mediator
+#
+# Spec shape: globals (campaign-wide) + games[] (per-game). A single run is just
+# one entry in games[]:
+#   npx tsx packages/model-harness/src/index.ts run runs/claude-totc.yaml
+
+globals:
+  server: http://localhost:8787
+  identities: ephemeral
+  output: ./runs/out
+  limits:
+    maxModelCallsPerBot: 200
+    wallClockMsPerRun: 900000
+  analysis:
+    enabled: true
     model: haiku
-    count: 2
-  - persona: ./personas/win-focused-opportunist
-    model: haiku
-    count: 2
-limits:
-  maxModelCallsPerBot: 200
-  wallClockMsPerRun: 900000
-analysis:
-  enabled: true
-  model: haiku
+
+games:
+  - game: tragedy-of-the-commons
+    rounds: 8
+    params:
+      teamSize: 4
+    seats:
+      - persona: ./personas/peaceful-mediator
+        model: haiku
+        count: 2
+      - persona: ./personas/win-focused-opportunist
+        model: haiku
+        count: 2

--- a/runs/treachery-study.yaml
+++ b/runs/treachery-study.yaml
@@ -10,63 +10,58 @@
 #   - anthropic/claude-haiku        → 'claude'     (local creds, no API key)
 #   - openrouter/minimax/minimax-m2 → 'openrouter' (OPENROUTER_API_KEY)
 #
+# Spec shape: globals (campaign-wide) + games[] (per-game). A single run is just
+# one entry in games[].
+#
 # Run it:
 #   # 1. Start the server in another terminal:
 #   #    cd packages/workers-server && wrangler dev   # http://localhost:8787
 #   # 2. Export the OpenRouter key for the MiniMax seats:
 #   #    export OPENROUTER_API_KEY=sk-or-...
-#   # 3. Dry-run to inspect the seat plan (no network):
+#   # 3. Dry-run to inspect the run plan (no network):
 #   #    npx tsx packages/model-harness/src/index.ts run --dry-run runs/treachery-study.yaml
 #   # 4. Real batch:
 #   #    npx tsx packages/model-harness/src/index.ts run runs/treachery-study.yaml
 
-game: tragedy-of-the-commons
-# Game length. Now plumbed end-to-end: the harness forwards this to lobby create,
-# which seeds it as the game's maxRounds (previously ignored → games ran the
-# engine default of 12). Kept short so a mixed Claude+MiniMax table reaches
-# phase:finished well inside the batch budget; raise for a longer study.
-rounds: 4
-
-# Game sizing knobs forwarded to lobby create. teamSize 4 → a 4-seat lobby,
-# which exactly fills the four seats below so the game auto-starts.
-params:
-  teamSize: 4
-
-server: http://localhost:8787
-
-# Fresh wallets minted per run (no persistent pool needed for a study run).
-identities: ephemeral
-
-# Output root; a run-<timestamp> subdir is created per run.
-output: ./runs/out
-
-seats:
-  # Two patient coalition-builders on local-creds Claude Haiku.
-  - persona: ./personas/peaceful-mediator
+globals:
+  server: http://localhost:8787
+  # Fresh wallets minted per run (no persistent pool needed for a study run).
+  identities: ephemeral
+  # Output root; a campaign-<ts>/run-<ts>-<label> subdir is created per run.
+  output: ./runs/out
+  # Per-bot safety caps. Batch mode (not live), so we tolerate long, deliberate
+  # turns: generous ceilings. The run ends as soon as the game hits
+  # phase:finished, so these are backstops against a stalled bot, not a target.
+  limits:
+    maxModelCallsPerBot: 200
+    wallClockMsPerRun: 1200000 # 20 min cap
+  # Automated judge pass over the relay ground truth.
+  analysis:
+    enabled: true
     model: anthropic/claude-haiku
-    count: 2
+    lenses:
+      - betrayals
+      - brokenPledges
+      - deceptions
+      - coordination
+      - perBot
+      - notableMoments
+      - summary
 
-  # Two leverage-driven opportunists on MiniMax M2 via OpenRouter.
-  - persona: ./personas/win-focused-opportunist
-    model: openrouter/minimax/minimax-m2
-    count: 2
-
-# Per-bot safety caps. Batch mode (not live), so we tolerate long, deliberate
-# turns: generous ceilings. The run ends as soon as the game hits phase:finished,
-# so these are backstops against a stalled bot, not a target duration.
-limits:
-  maxModelCallsPerBot: 200
-  wallClockMsPerRun: 1200000 # 20 min cap
-
-# Automated judge pass over the relay ground truth.
-analysis:
-  enabled: true
-  model: anthropic/claude-haiku
-  lenses:
-    - betrayals
-    - brokenPledges
-    - deceptions
-    - coordination
-    - perBot
-    - notableMoments
-    - summary
+games:
+  - game: tragedy-of-the-commons
+    # Game length, plumbed end-to-end → the game's maxRounds. Kept short so a
+    # mixed Claude+MiniMax table reaches phase:finished well inside the budget.
+    rounds: 4
+    # teamSize 4 → a 4-seat lobby, exactly filling the four seats below.
+    params:
+      teamSize: 4
+    seats:
+      # Two patient coalition-builders on local-creds Claude Haiku.
+      - persona: ./personas/peaceful-mediator
+        model: anthropic/claude-haiku
+        count: 2
+      # Two leverage-driven opportunists on MiniMax M2 via OpenRouter.
+      - persona: ./personas/win-focused-opportunist
+        model: openrouter/minimax/minimax-m2
+        count: 2

--- a/wiki/development/model-harness.md
+++ b/wiki/development/model-harness.md
@@ -29,7 +29,7 @@ This **replaced** the old `scripts/run-model-harness.ts` (TotC-specific, sideste
 #    worker — see the wrangler.toml note; never re-add a [build] command there.
 cd packages/workers-server && npm run dev          # http://localhost:8787
 
-# 2. Resolve the seat plan without touching the network (no wallets, no calls):
+# 2. Resolve the run plan without touching the network (no wallets, no calls):
 npx tsx packages/model-harness/src/index.ts run --dry-run runs/treachery-study.yaml
 
 # 3. Run a batch (+ judge if analysis.enabled). OpenRouter seats need the key:
@@ -40,34 +40,40 @@ OPENROUTER_API_KEY=sk-or-... INSPECTOR_TOKEN=local-inspector-token \
 npx tsx packages/model-harness/src/index.ts run runs/campaign-example.yaml
 
 # 5. Re-judge an existing run dir without re-playing the game:
-npx tsx packages/model-harness/src/index.ts analyze runs/out/run-<id> [--model anthropic/claude-haiku]
+npx tsx packages/model-harness/src/index.ts analyze runs/out/campaign-<id>/run-<id> [--model anthropic/claude-haiku]
 ```
 
-## Run-spec shape
+## Spec shape
 
-A single YAML (`runs/*.yaml`) drives a whole batch. The load-bearing fields:
+**One format, always:** `globals` (campaign-wide) + `games[]` (per-game). A single run is just one entry in `games`; a sweep is many — there is no separate flat single-spec shape. The load-bearing fields:
 
 ```yaml
-game: tragedy-of-the-commons   # any game implementing the CoordinationGame contract
-rounds: 4                      # plumbed end-to-end → game maxRounds (see gotcha below)
-params: { teamSize: 4 }        # game sizing, forwarded to lobby create
-identities: ephemeral          # fresh wallets per run, or 'pool' for ~/.coordination/bot-pool.json
-output: ./runs/out             # a run-<id> subdir is created per run
-seats:
-  - persona: ./personas/peaceful-mediator       # bundle dir: persona.md (+ context/*.md, persona.yaml)
-    model: anthropic/claude-haiku               # model string drives backend selection
-    count: 2                                    # expands to N seats (personas cycle)
-  - persona: ./personas/win-focused-opportunist
-    model: openrouter/minimax/minimax-m2
-    count: 2
-limits:
-  maxModelCallsPerBot: 200     # backstop against a stalled bot, not a target
-  wallClockMsPerRun: 1200000   # ditto; run ends as soon as phase:finished
-analysis:
-  enabled: true
-  model: anthropic/claude-haiku  # judge model (any backend)
-  lenses: [betrayals, brokenPledges, deceptions, coordination, perBot, notableMoments, summary]
+globals:                         # campaign-wide — applied to every entry
+  server: http://localhost:8787
+  identities: ephemeral          # fresh wallets per run, or 'pool' for ~/.coordination/bot-pool.json
+  output: ./runs/out             # a campaign-<id>/run-<id>-<label> subdir per run
+  limits:
+    maxModelCallsPerBot: 200     # backstop against a stalled bot, not a target
+    wallClockMsPerRun: 1200000   # ditto; a run ends as soon as phase:finished
+  analysis:
+    enabled: true
+    model: anthropic/claude-haiku  # judge model (any backend)
+    lenses: [betrayals, brokenPledges, deceptions, coordination, perBot, notableMoments, summary]
+games:                           # one entry = one game setup (1 or many)
+  - game: tragedy-of-the-commons # any game implementing the CoordinationGame contract
+    rounds: 4                    # plumbed end-to-end → game maxRounds
+    params: { teamSize: 4 }      # game sizing, forwarded to lobby create
+    repeats: 1                   # run this setup N× for variance (optional)
+    seats:
+      - persona: ./personas/peaceful-mediator     # bundle dir: persona.md (+ context/*.md, persona.yaml)
+        model: anthropic/claude-haiku             # model string drives backend selection
+        count: 2                                  # expands to N seats (personas cycle)
+      - persona: ./personas/win-focused-opportunist
+        model: openrouter/minimax/minimax-m2
+        count: 2
 ```
+
+Scope is a **strict partition** — every field lives in exactly one section (`globals` vs a `games[]` entry), never both; a misplaced field is a hard error. See [Campaigns](#campaigns-research-sweeps) below for the full field table, `repeats`, and multi-game sweeps.
 
 A **persona is a directory bundle**, not a string: `persona.md` (required, behavior/voice/strategy), optional `context/*.md` (concatenated, sorted), optional `persona.yaml` (`defaultModel`, `extraMcpServers`). Personas are model-agnostic on purpose — that's what lets you benchmark one persona across models. Refs resolve as absolute paths, package-relative (`./personas/...`), or bare bundled names.
 
@@ -89,38 +95,42 @@ Research is "hold everything constant, vary one axis." Two canonical recipes:
 **Model A/B — same persona, two brains** (which model plays the strategy better?):
 
 ```yaml
-game: tragedy-of-the-commons
-rounds: 4
-params: { teamSize: 4 }
-server: http://localhost:8787
-identities: ephemeral
-output: ./runs/out
-seats:
-  - { persona: ./personas/win-focused-opportunist, model: haiku, count: 2 }
-  - { persona: ./personas/win-focused-opportunist, model: openrouter/minimax/minimax-m2, count: 2 }
-limits: { maxModelCallsPerBot: 200, wallClockMsPerRun: 1200000 }
-analysis: { enabled: true, model: haiku }
+globals:
+  server: http://localhost:8787
+  identities: ephemeral
+  output: ./runs/out
+  limits: { maxModelCallsPerBot: 200, wallClockMsPerRun: 1200000 }
+  analysis: { enabled: true, model: haiku }
+games:
+  - game: tragedy-of-the-commons
+    rounds: 4
+    params: { teamSize: 4 }
+    seats:
+      - { persona: ./personas/win-focused-opportunist, model: haiku, count: 2 }
+      - { persona: ./personas/win-focused-opportunist, model: openrouter/minimax/minimax-m2, count: 2 }
 ```
 
 **Persona showdown — same model, four strategies** (no key; which strategy wins on one brain?):
 
 ```yaml
-game: tragedy-of-the-commons
-rounds: 4
-params: { teamSize: 4 }
-server: http://localhost:8787
-identities: ephemeral
-output: ./runs/out
-seats:
-  - { persona: ./personas/peaceful-mediator, model: haiku, count: 1 }
-  - { persona: ./personas/anti-overextractor, model: haiku, count: 1 }
-  - { persona: ./personas/win-focused-builder, model: haiku, count: 1 }
-  - { persona: ./personas/win-focused-opportunist, model: haiku, count: 1 }
-limits: { maxModelCallsPerBot: 200, wallClockMsPerRun: 1200000 }
-analysis: { enabled: true, model: haiku }
+globals:
+  server: http://localhost:8787
+  identities: ephemeral
+  output: ./runs/out
+  limits: { maxModelCallsPerBot: 200, wallClockMsPerRun: 1200000 }
+  analysis: { enabled: true, model: haiku }
+games:
+  - game: tragedy-of-the-commons
+    rounds: 4
+    params: { teamSize: 4 }
+    seats:
+      - { persona: ./personas/peaceful-mediator, model: haiku, count: 1 }
+      - { persona: ./personas/anti-overextractor, model: haiku, count: 1 }
+      - { persona: ./personas/win-focused-builder, model: haiku, count: 1 }
+      - { persona: ./personas/win-focused-opportunist, model: haiku, count: 1 }
 ```
 
-To **vary the game** instead, change `game:` to `capture-the-lobster` or `oathbreaker` and adjust `params`/`teamSize` — the harness is game-agnostic, so nothing else moves.
+To **vary the game** instead, change the entry's `game:` to `capture-the-lobster` or `oathbreaker` and adjust `params`/`teamSize` — the harness is game-agnostic, so nothing else moves. To run several at once, add more `games[]` entries (that's a campaign — next).
 
 ## Campaigns (research sweeps)
 
@@ -172,9 +182,7 @@ Runnable example: `runs/campaign-example.yaml` (all-haiku, no key).
                              "outcome": { /* game's own getOutcome */ }, "summary": { /* getSummaryFromSpectator */ } } } ] }
   ```
   Read `campaign.json` to compare outcomes across the batch without opening every run. Failed runs appear with `"status": "error"` + the message.
-- **Preview before you fire.** `run --dry-run <campaign.yaml>` prints the expanded grid (entries, total run count, per-entry backend mix) so you don't accidentally launch 200 games.
-
-A bare single-spec file (no `games:` key) is still a valid one-run spec — unchanged behavior, flat output, no campaign dir.
+- **Preview before you fire.** `run --dry-run <spec.yaml>` prints the expanded grid (entries, total run count, per-entry backend mix) so you don't accidentally launch 200 games.
 
 ### Going on-chain is a two-line change
 
@@ -190,7 +198,7 @@ Because `server` and `identities` are **globals**, flipping a whole sweep to the
 
 `claudeCliModel(model)` normalizes a claude-backend string into a CLI-valid `--model` (strip `anthropic/`|`claude/` prefix; map `claude-haiku`→`haiku`, etc.). Shared by the gameplay runner **and** the judge so both resolve aliases identically. The OpenRouter runner strips the `openrouter/` prefix before sending the rest verbatim.
 
-## Output anatomy (`runs/out/run-<id>/`)
+## Output anatomy (`runs/out/campaign-<id>/run-<id>-<label>/`)
 
 - `bots/<botName>.jsonl` — one event per line: `session` (start/finished/cap/error), `model_request`, `model_response`, `tool_call`, `tool_result`. The append-only ground truth for what each agent thought and did. (MiniMax transcripts run large — reasoning + every tool turn.)
 - `relay.jsonl` — the **relay ground truth** (messaging, attestations, per-game action records), pulled from the admin inspect's `gameInspect.relayMessages`. This is the canonical "what happened," independent of any bot's view. The judge cites it by index (`relayRefs`).


### PR DESCRIPTION
## Collapse the harness to one spec format

The model harness supported **two** spec file formats:
- **bare single-spec** — `{ game, rounds, seats, server, ... }` flat at the root
- **campaign** — `{ globals, games[] }`

The bare format is a *pure subset* of the campaign one — a single run is just a one-entry `games` list. Supporting both was wasted code (and `loadSpec` wasn't even called anywhere). This collapses to **one format, one code path**.

### Changes
- **`spec.ts`** — removed `loadSpec` and the `!('games' in obj)` branch; `loadCampaign` now returns `CampaignRun[]` and requires `games`. A bare spec fails fast:
  > `spec at <path>: missing "games". A spec is { globals?, games: [...] } — a single run is just one entry in "games".`
- **`index.ts`** — `cmdRun` always routes through `runCampaign`; deleted the `form === 'single'` path, the now-dead `printSeatPlan`, and `maybeAnalyze` (**~113 fewer lines**).
- **`types.ts`** — dropped `LoadedCampaign` / the `form` discriminator.
- **Examples** — converted `runs/claude-totc.yaml` + `runs/treachery-study.yaml` to `globals`/`games`.
- **Wiki** — rewrote spec shape, blueprints, quickstart, and output paths to the one format.

### Net
**−119 lines of `src`** (26 added, 145 removed). A single game now lands at `campaign-<id>/run-<id>-<label>/` like any run — no special-case flat output.

### Validation
- `claude-totc.yaml` (1-game) plays end-to-end → `phase:finished`, **1/1 ok**, `campaign.json` written.
- `treachery-study.yaml` + `campaign-example.yaml` dry-run clean; bare-format spec correctly rejected.
- typecheck + Biome green.

Pre-launch repo, no backwards-compat: the bare format is gone, every consumer updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FRTtvwH7mgwtKKUgmsdbf
